### PR TITLE
chore(ci): do not trigger CI twice in pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Test
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
When pushing a commit to the existing PR, CI is being triggered twice, because it's both "push" and "pull_request" events. Instead, "push" event should only be triggered for the "main" branch