### PR TITLE
fix(component): fix folder location for generated qwik cmp

### DIFF
--- a/packages/qwik-nx/src/generators/component/generator.ts
+++ b/packages/qwik-nx/src/generators/component/generator.ts
@@ -24,7 +24,7 @@ function getDirectory(host: Tree, options: ComponentGeneratorSchema) {
   } else {
     baseDir =
       workspace.get(options.project).projectType === 'application'
-        ? 'app'
+        ? 'components'
         : 'lib';
   }
   return options.flat


### PR DESCRIPTION
https://github.com/qwikifiers/qwik-nx/issues/23

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Generating new components goes to the app folder instead of components.


# Use cases and why

- Actual

![image](https://user-images.githubusercontent.com/4918140/209425247-2d6dc796-2a42-4817-bfcc-60952fb6b38e.png)

- Expected
<img width="661" alt="Screenshot 2022-12-24 at 3 02 43 PM" src="https://user-images.githubusercontent.com/4918140/209425282-c5b47d26-280d-4397-98cf-03b280185eea.png">


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-nx/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
