### PR TITLE
fix: expose "tailwind" option in application generator

### DIFF
--- a/packages/qwik-nx/src/generators/application/schema.json
+++ b/packages/qwik-nx/src/generators/application/schema.json
@@ -73,6 +73,11 @@
       "type": "boolean",
       "description": "Creates an application with strict mode and strict type checking.",
       "default": true
+    },
+    "tailwind": {
+      "description": "Setup Tailwind",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["name"]


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
Tailwind option is included in both `preset` and `application` generators, but is actually exposed only in `preset` one
