### PR TITLE
fix: run all installation commands in serial

### DIFF
--- a/packages/qwik-nx/src/generators/application/generator.spec.ts
+++ b/packages/qwik-nx/src/generators/application/generator.spec.ts
@@ -5,6 +5,9 @@ import generator from './generator';
 import { QwikAppGeneratorSchema } from './schema';
 import { Linter } from '@nrwl/linter';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const devkit = require('@nrwl/devkit');
+
 describe('qwik-nx generator', () => {
   let appTree: Tree;
   const defaultOptions: QwikAppGeneratorSchema = {
@@ -17,8 +20,10 @@ describe('qwik-nx generator', () => {
     e2eTestRunner: 'none',
   };
 
+  jest.spyOn(devkit, 'ensurePackage').mockReturnValue(Promise.resolve());
+
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
+    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
   });
 
   it('should run successfully', async () => {
@@ -33,8 +38,9 @@ describe('qwik-nx generator', () => {
         ...defaultOptions,
         e2eTestRunner: 'none',
       });
-      const config = readProjectConfiguration(appTree, 'myapp-e2e');
-      expect(config).not.toBeDefined();
+      expect(() => readProjectConfiguration(appTree, 'myapp-e2e')).toThrowError(
+        `Cannot find configuration for 'myapp-e2e'`
+      );
     });
 
     it('--e2eTestRunner playwright', async () => {

--- a/packages/qwik-nx/src/generators/application/generator.ts
+++ b/packages/qwik-nx/src/generators/application/generator.ts
@@ -85,7 +85,7 @@ export default async function (tree: Tree, options: QwikAppGeneratorSchema) {
     const twOptions: SetupTailwindOptions = {
       project: normalizedOptions.name,
     };
-    await setupTailwindGenerator(tree, twOptions);
+    tasks.push(await setupTailwindGenerator(tree, twOptions));
   }
 
   return runTasksInSerial(...tasks);

--- a/packages/qwik-nx/src/generators/init/init.spec.ts
+++ b/packages/qwik-nx/src/generators/init/init.spec.ts
@@ -1,5 +1,5 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+import { Tree, readJson } from '@nrwl/devkit';
 
 import generator from './init';
 import { InitGeneratorSchema } from './schema';
@@ -14,7 +14,19 @@ describe('init generator', () => {
 
   it('should run successfully', async () => {
     await generator(appTree, options);
-    const config = readProjectConfiguration(appTree, 'test');
-    expect(config).toBeDefined();
+    const { devDependencies } = readJson(appTree, 'package.json');
+    expect(devDependencies['@builder.io/qwik']).toBeDefined();
+    expect(devDependencies['@builder.io/qwik-city']).toBeDefined();
+    expect(devDependencies['@types/eslint']).toBeDefined();
+    expect(devDependencies['@types/node']).toBeDefined();
+    expect(devDependencies['@typescript-eslint/eslint-plugin']).toBeDefined();
+    expect(devDependencies['@typescript-eslint/parser']).toBeDefined();
+    expect(devDependencies['eslint']).toBeDefined();
+    expect(devDependencies['eslint-plugin-qwik']).toBeDefined();
+    expect(devDependencies['node-fetch']).toBeDefined();
+    expect(devDependencies['prettier']).toBeDefined();
+    expect(devDependencies['typescript']).toBeDefined();
+    expect(devDependencies['vite']).toBeDefined();
+    expect(devDependencies['vite-tsconfig-paths']).toBeDefined();
   });
 });

--- a/packages/qwik-nx/src/generators/init/init.ts
+++ b/packages/qwik-nx/src/generators/init/init.ts
@@ -1,4 +1,4 @@
-import { addDependenciesToPackageJson, Tree } from '@nrwl/devkit';
+import { addDependenciesToPackageJson, formatFiles, Tree } from '@nrwl/devkit';
 import {
   eslintVersion,
   nodeFetchVersion,
@@ -13,6 +13,7 @@ import {
   viteVersion,
 } from '../../utils/versions';
 import { InitGeneratorSchema } from './schema';
+import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 
 function updateDependencies(host: Tree) {
   return addDependenciesToPackageJson(
@@ -41,5 +42,9 @@ export default async function qwikInitGenerator(
   options: InitGeneratorSchema
 ) {
   const installTask = updateDependencies(tree);
-  await installTask();
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+  return runTasksInSerial(installTask);
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
All install tasks should be executed sequentially in the end. Running them in other places resulted in installation commands running multiple times and also failed unit tests
