### PR TITLE
feat: cloudflare pages integration

### DIFF
--- a/packages/qwik-nx/generators.json
+++ b/packages/qwik-nx/generators.json
@@ -49,6 +49,11 @@
       "factory": "./src/generators/e2e-project/generator",
       "schema": "./src/generators/e2e-project/schema.json",
       "description": "Create an E2E app for a Qwik app"
+    },
+    "cloudflare-pages-integration": {
+      "factory": "./src/generators/integrations/cloudflare-pages-integration/generator",
+      "schema": "./src/generators/integrations/cloudflare-pages-integration/schema.json",
+      "description": "Qwik City Cloudflare Pages adaptor allows you to connect Qwik City to Cloudflare Pages"
     }
   }
 }

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/adaptors/cloudflare-pages/vite.config.ts.template
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/adaptors/cloudflare-pages/vite.config.ts.template
@@ -1,0 +1,19 @@
+import { cloudflarePagesAdaptor } from '@builder.io/qwik-city/adaptors/cloudflare-pages/vite';
+import { extendConfig } from '@builder.io/qwik-city/vite';
+import baseConfig from '../../vite.config';
+
+export default extendConfig(baseConfig, () => {
+  return {
+    build: {
+      ssr: true,
+      rollupOptions: {
+        input: ['<%= projectRoot %>/src/entry.cloudflare-pages.tsx', '@qwik-city-plan'],
+      },
+    },
+    plugins: [
+      cloudflarePagesAdaptor({
+        staticGenerate: true,
+      }),
+    ],
+  };
+});

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/functions/[[path]].ts.template
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/functions/[[path]].ts.template
@@ -1,0 +1,6 @@
+// eslint-disable-next-line
+// @ts-ignore
+
+// Cloudflare Pages Functions
+// https://developers.cloudflare.com/pages/platform/functions/
+export { onRequest } from '<%= offsetFromRoot %>../dist/<%= projectRoot %>/server/entry.cloudflare-pages';

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/public/_headers.template
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/public/_headers.template
@@ -1,0 +1,4 @@
+# https://developers.cloudflare.com/pages/platform/headers/
+
+/build/*
+  Cache-Control: public, max-age=31536000, s-maxage=31536000, immutable

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/public/_redirects.template
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/public/_redirects.template
@@ -1,0 +1,1 @@
+# https://developers.cloudflare.com/pages/platform/redirects/

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/src/entry.cloudflare-pages.tsx.template
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/files/src/entry.cloudflare-pages.tsx.template
@@ -1,0 +1,16 @@
+/*
+ * WHAT IS THIS FILE?
+ *
+ * It's the  entry point for cloudflare-pages when building for production.
+ *
+ * Learn more about the cloudflare integration here:
+ * - https://qwik.builder.io/integrations/deployments/cloudflare-pages/
+ *
+ */
+import { createQwikCity } from '@builder.io/qwik-city/middleware/cloudflare-pages';
+import qwikCityPlan from '@qwik-city-plan';
+import render from './entry.ssr';
+
+const onRequest = createQwikCity({ render, qwikCityPlan });
+
+export { onRequest };

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/generator.spec.ts
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/generator.spec.ts
@@ -1,0 +1,102 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {
+  Tree,
+  readProjectConfiguration,
+  readJson,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+
+import generator from './generator';
+import applicationGenerator from './../../application/generator';
+import { CloudflarePagesIntegrationGeneratorSchema } from './schema';
+import { Linter } from '@nrwl/linter';
+
+describe('cloudflare-pages-integration generator', () => {
+  let appTree: Tree;
+  const projectName = 'test-project';
+  const options: CloudflarePagesIntegrationGeneratorSchema = {
+    project: projectName,
+  };
+
+  beforeEach(() => {
+    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+    applicationGenerator(appTree, {
+      name: projectName,
+      e2eTestRunner: 'none',
+      linter: Linter.None,
+      skipFormat: false,
+      strict: true,
+      style: 'css',
+      unitTestRunner: 'none',
+    });
+  });
+
+  it('should add required targets', async () => {
+    await generator(appTree, options);
+    const config = readProjectConfiguration(appTree, projectName);
+    expect(
+      config.targets['build-ssr'].configurations['cloudflare-pages']
+    ).toEqual({
+      configFile: `apps/${projectName}/adaptors/cloudflare-pages/vite.config.ts`,
+    });
+    expect(config.targets['deploy']).toEqual({
+      executor: '@k11r/nx-cloudflare-wrangler:deploy-page',
+      options: {
+        dist: `dist/apps/${projectName}/client`,
+      },
+      dependsOn: ['build-ssr-cloudflare-pages'],
+    });
+    expect(config.targets['preview-cloudflare-pages']).toEqual({
+      executor: '@k11r/nx-cloudflare-wrangler:serve-page',
+      options: {
+        dist: `dist/apps/${projectName}/client`,
+      },
+      dependsOn: ['build-ssr-cloudflare-pages'],
+    });
+    expect(config.targets['build-ssr-cloudflare-pages']).toEqual({
+      executor: 'nx:run-commands',
+      options: {
+        command: `npx nx run ${projectName}:build-ssr:cloudflare-pages`,
+      },
+    });
+  });
+
+  it('should add required dependencies', async () => {
+    await generator(appTree, options);
+    const { devDependencies } = readJson(appTree, 'package.json');
+    expect(devDependencies['wrangler']).toBeDefined();
+    expect(devDependencies['@k11r/nx-cloudflare-wrangler']).toBeDefined();
+  });
+
+  describe('should throw if project configuration does not meet the expectations', () => {
+    it('deploy target is already defined', async () => {
+      const config = readProjectConfiguration(appTree, projectName);
+      config.targets['deploy'] = { executor: 'nx:noop' };
+      updateProjectConfiguration(appTree, projectName, config);
+
+      expect(generator(appTree, options)).rejects.toThrow(
+        `"deploy" target has already been configured for ${options.project}`
+      );
+    });
+    it('project is not an application', async () => {
+      const config = readProjectConfiguration(appTree, projectName);
+      config.projectType = 'library';
+      updateProjectConfiguration(appTree, projectName, config);
+
+      expect(generator(appTree, options)).rejects.toThrow(
+        'Cannot setup cloudflare integration for the given project.'
+      );
+    });
+
+    it('project does not have Qwik\'s "build-ssr" target', async () => {
+      const config = readProjectConfiguration(appTree, projectName);
+      delete config.targets['build-ssr'];
+      updateProjectConfiguration(appTree, projectName, config);
+
+      expect(generator(appTree, options)).rejects.toThrow(
+        'Cannot setup cloudflare integration for the given project.'
+      );
+    });
+  });
+});

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/generator.ts
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/generator.ts
@@ -1,0 +1,131 @@
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  generateFiles,
+  GeneratorCallback,
+  joinPathFragments,
+  names,
+  offsetFromRoot,
+  ProjectConfiguration,
+  readProjectConfiguration,
+  TargetConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { nxCloudflareWrangler, wranglerVersion } from '../../../utils/versions';
+import { CloudflarePagesIntegrationGeneratorSchema } from './schema';
+
+interface NormalizedOptions {
+  offsetFromRoot: string;
+  projectConfig: ProjectConfiguration;
+}
+
+export default async function (
+  tree: Tree,
+  options: CloudflarePagesIntegrationGeneratorSchema
+) {
+  const config = readProjectConfiguration(tree, options.project);
+  if (config.projectType !== 'application' || !config.targets['build-ssr']) {
+    throw new Error(
+      'Cannot setup cloudflare integration for the given project.'
+    );
+  }
+  if (config.targets['deploy']) {
+    throw new Error(
+      `"deploy" target has already been configured for ${options.project}`
+    );
+  }
+
+  const normalizedOptions = normalizeOptions(config);
+  (config.targets['build-ssr'].configurations ??= {})['cloudflare-pages'] =
+    getBuildSSRTargetCloudflareConfiguration(normalizedOptions);
+  config.targets['deploy'] = getDeployTarget(normalizedOptions);
+  config.targets['preview-cloudflare-pages'] =
+    getCloudflarePreviewTarget(normalizedOptions);
+  config.targets['build-ssr-cloudflare-pages'] =
+    getIntermediateDependsOnTarget(normalizedOptions);
+
+  updateProjectConfiguration(tree, options.project, config);
+
+  addFiles(tree, normalizedOptions);
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+
+  return addCloudflarePagesDependencies(tree);
+}
+
+function getBuildSSRTargetCloudflareConfiguration(options: NormalizedOptions) {
+  return {
+    configFile: `${options.projectConfig.root}/adaptors/cloudflare-pages/vite.config.ts`,
+  };
+}
+
+function getDeployTarget(options: NormalizedOptions): TargetConfiguration {
+  return {
+    executor: '@k11r/nx-cloudflare-wrangler:deploy-page',
+    options: {
+      dist: `dist/${options.projectConfig.root}/client`,
+    },
+    dependsOn: ['build-ssr-cloudflare-pages'],
+  };
+}
+
+function getCloudflarePreviewTarget(
+  options: NormalizedOptions
+): TargetConfiguration {
+  return {
+    executor: '@k11r/nx-cloudflare-wrangler:serve-page',
+    options: {
+      dist: `dist/${options.projectConfig.root}/client`,
+    },
+    dependsOn: ['build-ssr-cloudflare-pages'],
+  };
+}
+
+/** Currently it's not possible to depend on a target with a specific configuration, that's why intermediate one is required */
+function getIntermediateDependsOnTarget(
+  options: NormalizedOptions
+): TargetConfiguration {
+  return {
+    executor: 'nx:run-commands',
+    options: {
+      command: `npx nx run ${options.projectConfig.name}:build-ssr:cloudflare-pages`,
+    },
+  };
+}
+
+function normalizeOptions(
+  projectConfig: ProjectConfiguration
+): NormalizedOptions {
+  return {
+    projectConfig,
+    offsetFromRoot: offsetFromRoot(projectConfig.root),
+  };
+}
+
+function addFiles(tree: Tree, options: NormalizedOptions): void {
+  const templateOptions = {
+    ...names(options.projectConfig.name),
+    projectRoot: options.projectConfig.root,
+    offsetFromRoot: options.offsetFromRoot,
+  };
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, 'files'),
+    options.projectConfig.root,
+    templateOptions
+  );
+}
+
+function addCloudflarePagesDependencies(tree: Tree): GeneratorCallback {
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      wrangler: wranglerVersion,
+      '@k11r/nx-cloudflare-wrangler': nxCloudflareWrangler,
+    }
+  );
+}

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/schema.d.ts
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/schema.d.ts
@@ -1,0 +1,4 @@
+export interface CloudflarePagesIntegrationGeneratorSchema {
+  project: string;
+  skipFormat?: boolean;
+}

--- a/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/schema.json
+++ b/packages/qwik-nx/src/generators/integrations/cloudflare-pages-integration/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "CloudflarePagesIntegration",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Project for the integration to be added",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": ["project"]
+}

--- a/packages/qwik-nx/src/utils/versions.ts
+++ b/packages/qwik-nx/src/utils/versions.ts
@@ -19,6 +19,10 @@ export const tailwindcssVersion = '3.1.8';
 // nxkit packages
 export const nxKitVersion = '^2.0.1';
 
+// cloudflare-pages integration
+export const wranglerVersion = 'latest';
+export const nxCloudflareWrangler = '^2.0.0';
+
 // other
 export const eslintVersion = '8.28.0';
 export const tsEslintVersion = '5.43.0';


### PR DESCRIPTION
Adding integration for cloudflare pages https://qwik.builder.io/integrations/deployments/cloudflare-pages/

The behavior is slightly different from what qwik generates: we're providing an actual deployment target `deploy` (equivalent of `npx wrangler pages publish`) along with `preview-cloudflare-pages`, while in qwik's internal generator they're giving only a preview option (`npx wrangler pages dev`). 