### PR TITLE
fix(qwik-nx): preview target should not get ssr param

### DIFF
--- a/packages/qwik-nx/src/generators/application/utils/get-qwik-application-project-params.ts
+++ b/packages/qwik-nx/src/generators/application/utils/get-qwik-application-project-params.ts
@@ -56,6 +56,7 @@ function getPreviewTarget(
     executor: '@nrwl/vite:preview-server',
     options: {
       buildTarget: `${params.projectName}:build-ssr`,
+      ssr: null,
     },
     dependsOn: ['build'],
   };


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
`preview` mode inherits undesired "ssr" param from the buildTarget, which results in it being broken

closes #52
