### PR TITLE
Revert "feat: use @nrwl/vite:preview-server executor (#47)"

### DIFF
--- a/packages/qwik-nx/src/generators/application/utils/get-qwik-application-project-params.ts
+++ b/packages/qwik-nx/src/generators/application/utils/get-qwik-application-project-params.ts
@@ -53,11 +53,12 @@ function getPreviewTarget(
   params: UpdateQwikAppConfigurationParams
 ): TargetConfiguration {
   return {
-    executor: '@nrwl/vite:preview-server',
+    executor: 'nx:run-commands',
     options: {
-      buildTarget: `${params.projectName}:build-ssr`,
+      command: 'vite preview',
+      cwd: `${params.projectRoot}`,
     },
-    dependsOn: ['build'],
+    dependsOn: ['build-ssr'],
   };
 }
 function getTestTarget(


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
`preview-server` executor merges configuration options from itself and corresponding build target. Because of this we end up having `ssr` option in the preview configuration, which ends up having wrong dist path to serve the build assets. There's no quick fix that can be applied, so in order to not create confusion it's better to revert the change entirely
