### PR TITLE
fix(qwik-nx): preset and peer dependencies fixes

### DIFF
--- a/e2e/qwik-nx-e2e/tests/chore.spec.ts
+++ b/e2e/qwik-nx-e2e/tests/chore.spec.ts
@@ -1,0 +1,51 @@
+import {
+  checkFilesExist,
+  ensureNxProject,
+  readJson,
+  runNxCommandAsync,
+  uniq,
+} from '@nrwl/nx-plugin/testing';
+
+import {
+  runCommandUntil,
+  promisifiedTreeKill,
+  killPort,
+} from '@qwikifiers/e2e/utils';
+
+describe('appGenerator e2e', () => {
+  // Setting up individual workspaces per
+  // test can cause e2e runs to take a long time.
+  // For this reason, we recommend each suite only
+  // consumes 1 workspace. The tests should each operate
+  // on a unique project in the workspace, such that they
+  // are not dependant on one another.
+  beforeAll(() => {
+    ensureNxProject('qwik-nx', 'dist/packages/qwik-nx');
+  });
+
+  afterAll(async () => {
+    // `nx reset` kills the daemon, and performs
+    // some work which can help clean up e2e leftovers
+    await runNxCommandAsync('reset');
+  });
+
+  describe("qwik-nx's compiled package.json", () => {
+    let project: string;
+
+    it("qwik-nx's package.json should contain only expected dependencies", async () => {
+      const packageJson = readJson('node_modules/qwik-nx/package.json');
+
+      expect(packageJson.dependencies).toEqual({
+        '@nrwl/vite': '15.6.1',
+      });
+      expect(packageJson.peerDependencies).toEqual({
+        '@builder.io/qwik': '^0.16.0',
+        '@playwright/test': '^1.30.0',
+        undici: '^5.18.0',
+        vite: '^4.0.0',
+        vitest: '^0.25.0',
+        tslib: '2.4.1',
+      });
+    }, 200000);
+  });
+});

--- a/packages/qwik-nx/package.json
+++ b/packages/qwik-nx/package.json
@@ -22,10 +22,13 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@nrwl/vite": "~15.6.0"
+    "@nrwl/vite": "^15.6.0"
   },
   "peerDependencies": {
     "@builder.io/qwik": "^0.16.0",
-    "vite": "~4.1.1"
+    "vite": "^4.0.0",
+    "vitest": "^0.25.0",
+    "@playwright/test": "^1.30.0",
+    "undici": "^5.18.0"
   }
 }

--- a/packages/qwik-nx/src/generators/preset/schema.json
+++ b/packages/qwik-nx/src/generators/preset/schema.json
@@ -8,10 +8,6 @@
     "qwikAppName": {
       "type": "string",
       "description": "",
-      "$default": {
-        "$source": "argv",
-        "index": 0
-      },
       "x-prompt": "App Name"
     },
     "tags": {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
1. when running `npx create-nx-workspace somename --preset-qwik-nx`, qwik-nx:preset generator uses default argument `somename` for the application name, while it is supposed to only be used for the workspace name
2. @nrwl/js:tsc executor builds qwik-nx package and includes dependencies of dependencies in its package.json. SInce this is happening, we should at least specify wider range of dependencies in order to not limit users to a single strict version
