### PR TITLE
fix(qwik-nx): added missing path import statement for tailwind template

### DIFF
--- a/packages/qwik-nx/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__
+++ b/packages/qwik-nx/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__
@@ -1,3 +1,5 @@
+const { join } = require('path');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests

# Description

Added a missing import statement `const { join } = require('path');` in the `tailwind.config.js__tmpl__` which is causing this error - https://github.com/qwikifiers/qwik-nx/issues/70

# Use cases and why

When tailwind is added via generator there should not be any errors.
closes https://github.com/qwikifiers/qwik-nx/issues/70

# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-nx/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
