### PR TITLE
feat(qwik-nx): bump up versions of the dependencies

### DIFF
--- a/e2e/qwik-nx-e2e/tests/chore.spec.ts
+++ b/e2e/qwik-nx-e2e/tests/chore.spec.ts
@@ -35,10 +35,9 @@ describe('appGenerator e2e', () => {
     it("qwik-nx's package.json should contain only expected dependencies", async () => {
       const packageJson = readJson('node_modules/qwik-nx/package.json');
 
-      expect(packageJson.dependencies).toEqual({
-        '@nrwl/vite': '15.6.1',
-      });
+      expect(packageJson.dependencies).toBeUndefined();
       expect(packageJson.peerDependencies).toEqual({
+        '@nrwl/vite': '^15.6.0',
         '@builder.io/qwik': '^0.16.0',
         '@playwright/test': '^1.30.0',
         undici: '^5.18.0',

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -2,18 +2,7 @@
 
 import { runNxCommandAsync, uniq, tmpProjPath } from '@nrwl/nx-plugin/testing';
 import { ChildProcess, exec, execSync } from 'child_process';
-import {
-  createFileSync,
-  ensureDirSync,
-  readdirSync,
-  readFileSync,
-  removeSync,
-  renameSync,
-  statSync,
-  writeFileSync,
-} from 'fs-extra';
-import * as path from 'path';
-import { join } from 'path';
+import { readdirSync, readFileSync, removeSync, statSync } from 'fs-extra';
 import { check as portCheck } from 'tcp-port-used';
 import { promisify } from 'util';
 import * as chalk from 'chalk';
@@ -22,8 +11,6 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
 } from 'nx/src/utils/package-manager';
-import { readJsonFile } from 'nx/src/utils/fileutils';
-import { workspaceRoot } from 'nx/src/utils/workspace-root';
 
 const kill = require('kill-port');
 export const isWindows = require('is-windows');
@@ -33,21 +20,10 @@ export const promisifiedTreeKill: (
   signal: string
 ) => Promise<void> = promisify(treeKill);
 
-export function getNxVersion(): string {
-  const { dependencies } = readJsonFile(
-    join(workspaceRoot, `./dist/packages/qwik-nx/package.json`)
-  );
-  const version = dependencies['@nrwl/vite'];
-  if (!version) {
-    throw new Error('Could not retrieve Nx version');
-  }
-  return version;
-}
-
 function getAdditionalPackageManagerCommands() {
   const pm = detectPackageManager();
   const [npmMajorVersion] = execSync(`npm -v`).toString().split('.');
-  const publishedVersion = getNxVersion();
+  const publishedVersion = execSync('npm view nx version');
   if (pm === 'npm') {
     return {
       createWorkspace: `npx ${

--- a/packages/qwik-nx/package.json
+++ b/packages/qwik-nx/package.json
@@ -21,10 +21,8 @@
   },
   "generators": "./generators.json",
   "executors": "./executors.json",
-  "dependencies": {
-    "@nrwl/vite": "^15.6.0"
-  },
   "peerDependencies": {
+    "@nrwl/vite": "^15.6.0",
     "@builder.io/qwik": "^0.16.0",
     "vite": "^4.0.0",
     "vitest": "^0.25.0",

--- a/packages/qwik-nx/src/utils/add-common-qwik-dependencies.ts
+++ b/packages/qwik-nx/src/utils/add-common-qwik-dependencies.ts
@@ -7,6 +7,7 @@ import {
   nodeFetchVersion,
   qwikCityVersion,
   qwikVersion,
+  undiciVersion,
   viteTsconfigPathsVersion,
   viteVersion,
 } from './versions';
@@ -21,6 +22,7 @@ export function addCommonQwikDependencies(host: Tree): GeneratorCallback {
       vite: viteVersion,
       'vite-tsconfig-paths': viteTsconfigPathsVersion,
       'node-fetch': nodeFetchVersion,
+      undici: undiciVersion,
       // TODO: dependencies below should be setup correctly by Nx's generator, so not needed to provide them here?
       // "@types/eslint": typesEslint,
       // '@types/node': 'latest',

--- a/packages/qwik-nx/src/utils/versions.ts
+++ b/packages/qwik-nx/src/utils/versions.ts
@@ -1,32 +1,33 @@
 // qwik packages
-export const qwikVersion = '0.16.2';
-export const qwikCityVersion = '0.0.128';
-export const qwikEslintPluginVersion = '0.16.2';
+export const qwikVersion = '~0.17.5';
+export const qwikCityVersion = '~0.1.0';
+export const qwikEslintPluginVersion = '~0.17.5';
 
 // css preprocessors
-export const sassVersion = '1.56.1';
-export const lessVersion = '4.1.3';
-export const stylusVersion = '0.59.0';
+export const sassVersion = '~1.56.1';
+export const lessVersion = '~4.1.3';
+export const stylusVersion = '~0.59.0';
 
-export const viteVersion = '4.0.4';
-export const viteTsconfigPathsVersion = '4.0.3';
-export const vitestVersion = '0.25.8';
+export const undiciVersion = '^5.18.0';
+export const viteVersion = '~4.1.1';
+export const viteTsconfigPathsVersion = '~4.0.3';
+export const vitestVersion = '^0.25.8';
 
-export const autoprefixerVersion = '10.4.11';
-export const postcssVersion = '8.4.16';
-export const tailwindcssVersion = '3.1.8';
+export const autoprefixerVersion = '~10.4.11';
+export const postcssVersion = '~8.4.16';
+export const tailwindcssVersion = '~3.1.8';
 
 // nxkit packages
 export const nxKitVersion = '^2.1.1';
 
 // cloudflare-pages integration
-export const wranglerVersion = 'latest';
+export const wranglerVersion = '^2.8.0';
 export const nxCloudflareWrangler = '^2.0.0';
 
 // other
-export const eslintVersion = '8.28.0';
-export const tsEslintVersion = '5.43.0';
-export const prettierVersion = '2.7.1';
-export const typescriptVersion = '4.9.3';
-export const nodeFetchVersion = '3.3.0';
-export const typesEslint = '8.4.10';
+export const eslintVersion = '~8.28.0';
+export const tsEslintVersion = '~5.43.0';
+export const prettierVersion = '~2.7.1';
+export const typescriptVersion = '~4.9.3';
+export const nodeFetchVersion = '~3.3.0';
+export const typesEslint = '~8.4.10';


### PR DESCRIPTION
- updated qwik and its related dependencies to latest versions
- moved @nrwl/vite to the peer dependencies, we don't want to depend on a strict version of this package