### PR TITLE
fix(qwik-nx): fix the name of the required name prop of preset generator

### DIFF
--- a/packages/qwik-nx/src/generators/preset/schema.json
+++ b/packages/qwik-nx/src/generators/preset/schema.json
@@ -73,5 +73,5 @@
       "default": "none"
     }
   },
-  "required": ["name"]
+  "required": ["qwikAppName"]
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
required property name is invalid
