### PR TITLE
fix(qwik-nx): check for eslint file existance before reading it

### DIFF
--- a/packages/qwik-nx/src/utils/configure-eslint.ts
+++ b/packages/qwik-nx/src/utils/configure-eslint.ts
@@ -19,7 +19,12 @@ export function configureEslint(
     cfg.root,
     '.eslintrc.json'
   );
-  const existingLibEslintConfig = tree.read(existingLibEslintConfigPath);
+
+  let existingLibEslintConfig: Buffer | undefined;
+
+  if (tree.exists(existingLibEslintConfigPath)) {
+    existingLibEslintConfig = tree.read(existingLibEslintConfigPath);
+  }
 
   lintProjectGenerator(tree, {
     project: project,
@@ -34,7 +39,10 @@ export function configureEslint(
 
   const viteConfigFileName = 'vite.config.ts';
   const eslintIgnorePath = './.eslintignore';
-  const eslintIgnore = tree.read(eslintIgnorePath)?.toString() ?? '';
+  let eslintIgnore = '';
+  if (tree.exists(eslintIgnorePath)) {
+    eslintIgnore = tree.read(eslintIgnorePath)?.toString() ?? '';
+  }
   if (!eslintIgnore.includes(viteConfigFileName)) {
     tree.write(
       eslintIgnorePath,


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
If eslint files don't exist in the repository, `configureEslint` may fail. To prevent this, it's required to firstly check for file existance
