### PR TITLE
fix(qwik-nx): use approximate version for @nrwl/vite package

### DIFF
--- a/e2e/qwik-nx-e2e/tests/chore.spec.ts
+++ b/e2e/qwik-nx-e2e/tests/chore.spec.ts
@@ -37,7 +37,7 @@ describe('appGenerator e2e', () => {
 
       expect(packageJson.dependencies).toBeUndefined();
       expect(packageJson.peerDependencies).toEqual({
-        '@nrwl/vite': '^15.6.0',
+        '@nrwl/vite': '~15.6.0',
         '@builder.io/qwik': '^0.16.0',
         '@playwright/test': '^1.30.0',
         undici: '^5.18.0',

--- a/packages/qwik-nx/package.json
+++ b/packages/qwik-nx/package.json
@@ -22,7 +22,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@nrwl/vite": "^15.6.0",
+    "@nrwl/vite": "~15.6.0",
     "@builder.io/qwik": "^0.16.0",
     "vite": "^4.0.0",
     "vitest": "^0.25.0",


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
@nrwl/vite package may not be fully compatible between versions, so it is much safer to use approximate version instead of compatible
