### PR TITLE
chore: fix local package publishing

### DIFF
--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -1,0 +1,41 @@
+# path to a directory with all packages
+storage: ../tmp/local-registry/storage
+
+auth: # TODO
+  htpasswd:
+    file: ./htpasswd
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    cache: true
+  yarn:
+    url: https://registry.yarnpkg.com
+    cache: true
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    access: $all
+
+    # allow all users (including non-authenticated users) to publish/publish packages
+    publish: $all
+    unpublish: $all
+
+    # if package is not available locally, proxy requests to 'yarn' registry
+    proxy: npmjs
+
+# log settings
+logs:
+  type: stdout
+  format: pretty
+  level: http

--- a/.verdaccio/htpasswd
+++ b/.verdaccio/htpasswd
@@ -1,0 +1,1 @@
+test:5Y30XDhEQaJmQ:autocreated 2023-02-19T13:45:24.361Z

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,19 +141,19 @@ After your pull request is merged, you can safely delete your branch and pull th
 ## ▶ 9. Publishing to a local registry
 
 To test if your changes will actually work once the changes are published,
-it can be useful to publish locally to *Verdaccio*, a lightweight Node.js private proxy registry.
+it can be useful to publish to a local registry.
 
-**In Terminal 1, Install and launch Verdaccio**
-- Run `npm i -g verdaccio` in Terminal 1 (keep it running)
-- Run `verdaccio`
+- Run `pnpm run local-registry start` in Terminal 1 (keep it running)
+- Run `npm adduser --registry http://localhost:4873` in Terminal 2 (real credentials are not required, you just need to
+  be logged in. You can use test/test/test@test.io.)
+- Run `pnpm run local-registry enable` in Terminal 2
+- Run `pnpm run nx run qwik-nx:publish:local` in Terminal 2. You can set the version you want to publish in the package's package.json file.
 
-**In Terminal 2, Add a user and execute Nx commands to populate the local Verdaccio repository**
-- Run `npm adduser --registry http://localhost:4873 --auth-type=legacy`
-  
-  *(real credentials are not required, you just need to be logged in. You can use your own login details.)*
+If you have problems publishing, make sure you use Node 18 and NPM 8. Alternatively to running the project's "publish" target you can build and publish manually by running `pnpm run nx build:qwik-nx && cd dist/projects/qwik-nx && npm publish --registry=http://localhost:4873`
 
-- Run `nx publish [package] --registry=http://localhost:4873`
-- Run `nx publish qwik-nx --registry=http://localhost:4873`
+**NOTE:** After you finish with local testing don't forget to stop the local registry (e.g. closing the Terminal 1) and disabling the local registry using `pnpm run local-registry disable`. Keeping local registry enabled will change your lock file resolutions to `localhost:4873` on the next `pnpm install`. You can also run `pnpm run local-registry clear` to clean all packages in that local registry.
+
+**NOTE:** To use this newly published local version, you need to make a new workspace or change your target package to this new version, eg: `"qwik-nx": "^1.0.0",` and re-run `pnpm install` in your testing project.
 
 ### ▶ 10. That's it! Thank you for your contribution! 🙏💓
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "nx build",
     "commit": "git-cz",
     "format:fix": "pretty-quick --staged",
+    "local-registry": "./scripts/local-registry.sh",
     "prepare": "husky install",
     "start": "nx serve",
     "test": "nx test"
@@ -52,7 +53,7 @@
     "jest-environment-jsdom": "28.1.1",
     "jsonc-eslint-parser": "^2.1.0",
     "kill-port": "2.0.1",
-    "ngx-deploy-npm": "^4.3.11",
+    "ngx-deploy-npm": "^5.2.0",
     "nx": "15.6.1",
     "prettier": "^2.8.0",
     "pretty-quick": "^3.1.3",
@@ -61,6 +62,7 @@
     "ts-jest": "28.0.5",
     "ts-node": "10.9.1",
     "typescript": "~4.8.2",
+    "verdaccio": "5.21.1",
     "vite": "4.1.1"
   },
   "dependencies": {

--- a/packages/qwik-nx/project.json
+++ b/packages/qwik-nx/project.json
@@ -78,6 +78,11 @@
       "executor": "ngx-deploy-npm:deploy",
       "options": {
         "access": "public"
+      },
+      "configurations": {
+        "local": {
+          "registry": "http://localhost:4873"
+        }
       }
     },
     "push-to-github": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
       jest-environment-jsdom: 28.1.1
       jsonc-eslint-parser: ^2.1.0
       kill-port: 2.0.1
-      ngx-deploy-npm: ^4.3.11
+      ngx-deploy-npm: ^5.2.0
       nx: 15.6.1
       prettier: ^2.8.0
       pretty-quick: ^3.1.3
@@ -54,6 +54,7 @@ importers:
       ts-node: 10.9.1
       tslib: ^2.3.0
       typescript: ~4.8.2
+      verdaccio: 5.21.1
       vite: 4.1.1
     dependencies:
       '@swc/helpers': 0.4.14
@@ -99,7 +100,7 @@ importers:
       jest-environment-jsdom: 28.1.1
       jsonc-eslint-parser: 2.1.0
       kill-port: 2.0.1
-      ngx-deploy-npm: 4.3.11_nx@15.6.1+typescript@4.8.4
+      ngx-deploy-npm: 5.2.0_ewjtrlfj6y4uoq4loh4g4t525u
       nx: 15.6.1_lwc5ciab46qbgcufzept4zyhgi
       prettier: 2.8.0
       pretty-quick: 3.1.3_prettier@2.8.0
@@ -108,6 +109,7 @@ importers:
       ts-jest: 28.0.5_a2m7a45vovkhapf5c3dybebnnu
       ts-node: 10.9.1_tcnxy6afr3ybnfxcnv6dnehkpq
       typescript: 4.8.4
+      verdaccio: 5.21.1_typanion@3.12.1
       vite: 4.1.1_@types+node@16.11.7
 
   packages/qwik-nx:
@@ -2807,24 +2809,6 @@ packages:
       - typescript
     dev: true
 
-  /@nrwl/devkit/15.6.2_nx@15.6.1+typescript@4.8.4:
-    resolution:
-      {
-        integrity: sha512-RcPwjr1btr16wz/ZTnLeKMLu4zATWoh5E94qrFxw3n8hXbC5cIW0Hs/D3ho7cuJQCtQmItTD21M7akjvgHsniA==,
-      }
-    peerDependencies:
-      nx: '>= 14 <= 16'
-    dependencies:
-      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.8.4
-      ejs: 3.1.8
-      ignore: 5.2.0
-      nx: 15.6.1_lwc5ciab46qbgcufzept4zyhgi
-      semver: 7.3.4
-      tslib: 2.4.1
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-
   /@nrwl/eslint-plugin-nx/15.6.1_ydwymo3gcyussbsstvsesyfmha:
     resolution:
       {
@@ -3671,6 +3655,13 @@ packages:
       '@types/node': 16.11.7
     dev: true
 
+  /@types/lodash/4.14.191:
+    resolution:
+      {
+        integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==,
+      }
+    dev: true
+
   /@types/minimatch/3.0.5:
     resolution:
       {
@@ -3923,6 +3914,247 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /@verdaccio/commons-api/10.2.0:
+    resolution:
+      {
+        integrity: sha512-F/YZANu4DmpcEV0jronzI7v2fGVWkQ5Mwi+bVmV+ACJ+EzR0c9Jbhtbe5QyLUuzR97t8R5E/Xe53O0cc2LukdQ==,
+      }
+    engines: { node: '>=8' }
+    dependencies:
+      http-errors: 2.0.0
+      http-status-codes: 2.2.0
+    dev: true
+
+  /@verdaccio/config/6.0.0-6-next.60:
+    resolution:
+      {
+        integrity: sha512-q6r8JEXUV2piZUtWW5SR11vIVqO4b4OGKmAnwCf6EdszRoRcxzf9KBlktVxSzmoIUOvygf0a+3hGbGI9qZBSjw==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/core': 6.0.0-6-next.60
+      '@verdaccio/utils': 6.0.0-6-next.28
+      debug: 4.3.4
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      yaml: 2.2.0
+      yup: 0.32.11
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/config/6.0.0-6-next.61:
+    resolution:
+      {
+        integrity: sha512-gvR6vRS5aXTwEhZSecqEEOlTGHqbV2Vjg7w/huGRuAuJlOuz2t4V3d499U4qkkLBBEhh/X+4DjEVrkOo+jVWzQ==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/core': 6.0.0-6-next.61
+      '@verdaccio/utils': 6.0.0-6-next.29
+      debug: 4.3.4
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      yup: 0.32.11
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/core/6.0.0-6-next.60:
+    resolution:
+      {
+        integrity: sha512-ZCDOPGjC1rox2dKwZ38GyWA3muA5JlTSfJ15EoIzd8kkWekGtV4/qtua0xUoxH4MhrYQmycsMuelaRveDtSz9A==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      ajv: 8.11.2
+      core-js: 3.27.0
+      http-errors: 1.8.1
+      http-status-codes: 2.2.0
+      process-warning: 1.0.0
+      semver: 7.3.8
+    dev: true
+
+  /@verdaccio/core/6.0.0-6-next.61:
+    resolution:
+      {
+        integrity: sha512-F5TLiQB9leeoZnyKRcE1hH5pr3lD2hZsKoda4ljqPyN2SqQq6ni6VsJLIMU73WjRQSl8GU9FPs8VunZo7l5AyA==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      ajv: 8.11.2
+      core-js: 3.27.0
+      http-errors: 1.8.1
+      http-status-codes: 2.2.0
+      process-warning: 1.0.0
+      semver: 7.3.8
+    dev: true
+
+  /@verdaccio/file-locking/10.3.0:
+    resolution:
+      {
+        integrity: sha512-FE5D5H4wy/nhgR/d2J5e1Na9kScj2wMjlLPBHz7XF4XZAVSRdm45+kL3ZmrfA6b2HTADP/uH7H05/cnAYW8bhw==,
+      }
+    engines: { node: '>=8' }
+    dependencies:
+      lockfile: 1.0.4
+    dev: true
+
+  /@verdaccio/local-storage/10.3.1:
+    resolution:
+      {
+        integrity: sha512-f3oArjXPOAwUAA2dsBhfL/rSouqJ2sfml8k97RtnBPKOzisb28bgyAQW0mqwQvN4MTK5S/2xudmobFpvJAIatg==,
+      }
+    engines: { node: '>=8' }
+    dependencies:
+      '@verdaccio/commons-api': 10.2.0
+      '@verdaccio/file-locking': 10.3.0
+      '@verdaccio/streams': 10.2.0
+      async: 3.2.4
+      debug: 4.3.4
+      lodash: 4.17.21
+      lowdb: 1.0.0
+      mkdirp: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/logger-7/6.0.0-6-next.6:
+    resolution:
+      {
+        integrity: sha512-Lkm/FCP5ALKfsje+y17FXnGpGI7mnAyzPlF+TA1ZkMXyVnRsQO0sbYfjOenkZ9/IpkEJzwq+15mzyvxZzVsWMA==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/logger-commons': 6.0.0-6-next.29
+      pino: 7.11.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/logger-commons/6.0.0-6-next.29:
+    resolution:
+      {
+        integrity: sha512-7AFWin5Kgurprr+7B/swOX4vbNxDWl/yzHAe6spSN3GXheX6mjsbgu8msovXvu0ntqehyEWeSgI30lOnB4vjKQ==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/core': 6.0.0-6-next.61
+      '@verdaccio/logger-prettify': 6.0.0-6-next.9
+      colorette: 2.0.19
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/logger-prettify/6.0.0-6-next.9:
+    resolution:
+      {
+        integrity: sha512-+VZa/O4HgEGl5kuTUL86Nf3T5xrPBnrIPRMEiubW4Lytj2Jo9FTxxhAFyJ0QD4FSIZqyzi8Ul9jM0SKDxsTbdw==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      colorette: 2.0.19
+      dayjs: 1.11.7
+      lodash: 4.17.21
+      pino-abstract-transport: 1.0.0
+      sonic-boom: 3.2.1
+    dev: true
+
+  /@verdaccio/middleware/6.0.0-6-next.40:
+    resolution:
+      {
+        integrity: sha512-j7VT0sHM8OGEz2L1Tmff6oSjh8uHm40z96enUtFxpAJYELXx8KqGK82DHHl5FsCIB8GvdbFJn0YM1Bv4Gf5bvA==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/config': 6.0.0-6-next.61
+      '@verdaccio/core': 6.0.0-6-next.61
+      '@verdaccio/url': 11.0.0-6-next.27
+      '@verdaccio/utils': 6.0.0-6-next.29
+      debug: 4.3.4
+      express: 4.18.2
+      express-rate-limit: 5.5.1
+      lodash: 4.17.21
+      lru-cache: 7.14.1
+      mime: 2.6.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/streams/10.2.0:
+    resolution:
+      {
+        integrity: sha512-FaIzCnDg0x0Js5kSQn1Le3YzDHl7XxrJ0QdIw5LrDUmLsH3VXNi4/NMlSHnw5RiTTMs4UbEf98V3RJRB8exqJA==,
+      }
+    engines: { node: '>=8', npm: '>=5' }
+    dev: true
+
+  /@verdaccio/tarball/11.0.0-6-next.30:
+    resolution:
+      {
+        integrity: sha512-+lQn0FsPkuTrZnzWxJ9p1ZuQlctZoDuxqH5y6UoOJP49OJSEV14NrVIR0y8mRhgJRFOfBjyqDEoyH4gNkhnNoA==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/core': 6.0.0-6-next.61
+      '@verdaccio/url': 11.0.0-6-next.27
+      '@verdaccio/utils': 6.0.0-6-next.29
+      debug: 4.3.4
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/ui-theme/6.0.0-6-next.61:
+    resolution:
+      {
+        integrity: sha512-owS9KpIrG69KjJ5zoQa55qGQPQUKzcWN/giRk6lMpU8LXAKS0Ogpr86mzL4IgKg8DEHsfo0DWiBeWwXwr8HHFA==,
+      }
+    dev: true
+
+  /@verdaccio/url/11.0.0-6-next.27:
+    resolution:
+      {
+        integrity: sha512-Gj29AkqUZbpbGyN6vXxKejZt6lQBWhEmLHN6ajZgfmr/hqbTzx2VTetFIIFfuka72mHCOhnUn/hBFgh9fL1Hxw==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/core': 6.0.0-6-next.61
+      debug: 4.3.4
+      lodash: 4.17.21
+      validator: 13.7.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@verdaccio/utils/6.0.0-6-next.28:
+    resolution:
+      {
+        integrity: sha512-tEGIC7iYiDxZnrdBFB6O1cOdYOyeqE42MO4edtNLugbvAgh5iAntUI4qAGic8a39Od5JBm7QQ0RU3qHiofyU1w==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/core': 6.0.0-6-next.60
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      semver: 7.3.8
+    dev: true
+
+  /@verdaccio/utils/6.0.0-6-next.29:
+    resolution:
+      {
+        integrity: sha512-bIpZYaWTT+bKyUDyoTQxkGDd8us65o9OJtVLIKCrH2RKxpX5ONpwPCxemyFB8v5kErSbqRXXvvQQflbg3s+WHg==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/core': 6.0.0-6-next.61
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      semver: 7.3.8
+    dev: true
+
   /@yarnpkg/lockfile/1.1.0:
     resolution:
       {
@@ -3964,6 +4196,27 @@ packages:
       {
         integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==,
       }
+    dev: true
+
+  /abort-controller/3.0.0:
+    resolution:
+      {
+        integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==,
+      }
+    engines: { node: '>=6.5' }
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: true
+
+  /accepts/1.3.8:
+    resolution:
+      {
+        integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==,
+      }
+    engines: { node: '>= 0.6' }
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
     dev: true
 
   /acorn-globals/6.0.0:
@@ -4155,6 +4408,14 @@ packages:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  /apache-md5/1.1.8:
+    resolution:
+      {
+        integrity: sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==,
+      }
+    engines: { node: '>=8' }
+    dev: true
+
   /arg/4.1.3:
     resolution:
       {
@@ -4182,6 +4443,13 @@ packages:
         integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==,
       }
     engines: { node: '>=8' }
+    dev: true
+
+  /array-flatten/1.1.1:
+    resolution:
+      {
+        integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==,
+      }
     dev: true
 
   /array-ify/1.0.0:
@@ -4215,6 +4483,23 @@ packages:
     engines: { node: '>=8' }
     dev: true
 
+  /asn1/0.2.6:
+    resolution:
+      {
+        integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==,
+      }
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+
+  /assert-plus/1.0.0:
+    resolution:
+      {
+        integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==,
+      }
+    engines: { node: '>=0.8' }
+    dev: true
+
   /assertion-error/1.1.0:
     resolution:
       {
@@ -4240,6 +4525,28 @@ packages:
         integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==,
       }
     engines: { node: '>= 4.0.0' }
+    dev: true
+
+  /atomic-sleep/1.0.0:
+    resolution:
+      {
+        integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
+      }
+    engines: { node: '>=8.0.0' }
+    dev: true
+
+  /aws-sign2/0.7.0:
+    resolution:
+      {
+        integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==,
+      }
+    dev: true
+
+  /aws4/1.12.0:
+    resolution:
+      {
+        integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==,
+      }
     dev: true
 
   /axios/1.1.3:
@@ -4428,6 +4735,22 @@ packages:
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
 
+  /bcrypt-pbkdf/1.0.2:
+    resolution:
+      {
+        integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==,
+      }
+    dependencies:
+      tweetnacl: 0.14.5
+    dev: true
+
+  /bcryptjs/2.4.3:
+    resolution:
+      {
+        integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==,
+      }
+    dev: true
+
   /binary-extensions/2.2.0:
     resolution:
       {
@@ -4444,6 +4767,29 @@ packages:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.0
+
+  /body-parser/1.20.1:
+    resolution:
+      {
+        integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==,
+      }
+    engines: { node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16 }
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.1
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /brace-expansion/1.1.11:
     resolution:
@@ -4510,6 +4856,13 @@ packages:
       node-int64: 0.4.0
     dev: true
 
+  /buffer-equal-constant-time/1.0.1:
+    resolution:
+      {
+        integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==,
+      }
+    dev: true
+
   /buffer-from/1.1.2:
     resolution:
       {
@@ -4525,6 +4878,16 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  /buffer/6.0.3:
+    resolution:
+      {
+        integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==,
+      }
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: true
+
   /busboy/1.6.0:
     resolution:
       {
@@ -4535,12 +4898,38 @@ packages:
       streamsearch: 1.1.0
     dev: true
 
+  /bytes/3.0.0:
+    resolution:
+      {
+        integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
+  /bytes/3.1.2:
+    resolution:
+      {
+        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
   /cachedir/2.3.0:
     resolution:
       {
         integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==,
       }
     engines: { node: '>=6' }
+    dev: true
+
+  /call-bind/1.0.2:
+    resolution:
+      {
+        integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==,
+      }
+    dependencies:
+      function-bind: 1.1.1
+      get-intrinsic: 1.2.0
     dev: true
 
   /callsites/3.1.0:
@@ -4583,6 +4972,13 @@ packages:
       {
         integrity: sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==,
       }
+
+  /caseless/0.12.0:
+    resolution:
+      {
+        integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==,
+      }
+    dev: true
 
   /chai/4.3.7:
     resolution:
@@ -4708,6 +5104,17 @@ packages:
         integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==,
       }
     engines: { node: '>= 10' }
+    dev: true
+
+  /clipanion/3.2.0-rc.14_typanion@3.12.1:
+    resolution:
+      {
+        integrity: sha512-lj5zydbH786t6gpXe6oNX7CM5YKhd0CDhcXG8pKyRa2Nz5cgj1yhnNKxDi/MyPYwjyvAG5oVBeDdYCGUAgD8lQ==,
+      }
+    peerDependencies:
+      typanion: '*'
+    dependencies:
+      typanion: 3.12.1
     dev: true
 
   /cliui/6.0.0:
@@ -4893,6 +5300,34 @@ packages:
       dot-prop: 5.3.0
     dev: true
 
+  /compressible/2.0.18:
+    resolution:
+      {
+        integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==,
+      }
+    engines: { node: '>= 0.6' }
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
+  /compression/1.7.4:
+    resolution:
+      {
+        integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==,
+      }
+    engines: { node: '>= 0.8.0' }
+    dependencies:
+      accepts: 1.3.8
+      bytes: 3.0.0
+      compressible: 2.0.18
+      debug: 2.6.9
+      on-headers: 1.0.2
+      safe-buffer: 5.1.2
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /concat-map/0.0.1:
     resolution:
       {
@@ -4917,6 +5352,24 @@ packages:
       {
         integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==,
       }
+    dev: true
+
+  /content-disposition/0.5.4:
+    resolution:
+      {
+        integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==,
+      }
+    engines: { node: '>= 0.6' }
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /content-type/1.0.5:
+    resolution:
+      {
+        integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
+      }
+    engines: { node: '>= 0.6' }
     dev: true
 
   /conventional-changelog-angular/5.0.13:
@@ -5153,6 +5606,32 @@ packages:
         integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==,
       }
 
+  /cookie-signature/1.0.6:
+    resolution:
+      {
+        integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==,
+      }
+    dev: true
+
+  /cookie/0.5.0:
+    resolution:
+      {
+        integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
+  /cookies/0.8.0:
+    resolution:
+      {
+        integrity: sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==,
+      }
+    engines: { node: '>= 0.8' }
+    dependencies:
+      depd: 2.0.0
+      keygrip: 1.1.0
+    dev: true
+
   /core-js-compat/3.27.2:
     resolution:
       {
@@ -5161,11 +5640,37 @@ packages:
     dependencies:
       browserslist: 4.21.4
 
+  /core-js/3.27.0:
+    resolution:
+      {
+        integrity: sha512-wY6cKosevs430KRkHUIsvepDXHGjlXOZO3hYXNyqpD6JvB0X28aXyv0t1Y1vZMwE7SoKmtfa6IASHCPN52FwBQ==,
+      }
+    requiresBuild: true
+    dev: true
+
+  /core-util-is/1.0.2:
+    resolution:
+      {
+        integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==,
+      }
+    dev: true
+
   /core-util-is/1.0.3:
     resolution:
       {
         integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
       }
+    dev: true
+
+  /cors/2.8.5:
+    resolution:
+      {
+        integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==,
+      }
+    engines: { node: '>= 0.10' }
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
     dev: true
 
   /cosmiconfig-typescript-loader/4.2.0_yqziv553lqpp4o3uejsbvulp74:
@@ -5284,6 +5789,16 @@ packages:
     engines: { node: '>=8' }
     dev: true
 
+  /dashdash/1.14.1:
+    resolution:
+      {
+        integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==,
+      }
+    engines: { node: '>=0.10' }
+    dependencies:
+      assert-plus: 1.0.0
+    dev: true
+
   /data-urls/3.0.2:
     resolution:
       {
@@ -5301,6 +5816,27 @@ packages:
       {
         integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==,
       }
+    dev: true
+
+  /dayjs/1.11.7:
+    resolution:
+      {
+        integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==,
+      }
+    dev: true
+
+  /debug/2.6.9:
+    resolution:
+      {
+        integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
+      }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
     dev: true
 
   /debug/4.3.1:
@@ -5413,6 +5949,30 @@ packages:
       }
     engines: { node: '>=0.4.0' }
 
+  /depd/1.1.2:
+    resolution:
+      {
+        integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
+  /depd/2.0.0:
+    resolution:
+      {
+        integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
+  /destroy/1.2.0:
+    resolution:
+      {
+        integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==,
+      }
+    engines: { node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16 }
+    dev: true
+
   /detect-file/1.0.0:
     resolution:
       {
@@ -5521,6 +6081,44 @@ packages:
         integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==,
       }
 
+  /duplexify/4.1.2:
+    resolution:
+      {
+        integrity: sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==,
+      }
+    dependencies:
+      end-of-stream: 1.4.4
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+      stream-shift: 1.0.1
+    dev: true
+
+  /ecc-jsbn/0.1.2:
+    resolution:
+      {
+        integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==,
+      }
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+    dev: true
+
+  /ecdsa-sig-formatter/1.0.11:
+    resolution:
+      {
+        integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==,
+      }
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /ee-first/1.1.1:
+    resolution:
+      {
+        integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
+      }
+    dev: true
+
   /ejs/3.1.8:
     resolution:
       {
@@ -5551,6 +6149,14 @@ packages:
         integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
       }
 
+  /encodeurl/1.0.2:
+    resolution:
+      {
+        integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
   /end-of-stream/1.4.4:
     resolution:
       {
@@ -5567,6 +6173,15 @@ packages:
     engines: { node: '>=8.6' }
     dependencies:
       ansi-colors: 4.1.3
+
+  /envinfo/7.8.1:
+    resolution:
+      {
+        integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==,
+      }
+    engines: { node: '>=4' }
+    hasBin: true
+    dev: true
 
   /error-ex/1.3.2:
     resolution:
@@ -5615,6 +6230,13 @@ packages:
         integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==,
       }
     engines: { node: '>=6' }
+
+  /escape-html/1.0.3:
+    resolution:
+      {
+        integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
+      }
+    dev: true
 
   /escape-string-regexp/1.0.5:
     resolution:
@@ -5852,6 +6474,30 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
+  /etag/1.8.1:
+    resolution:
+      {
+        integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
+  /event-target-shim/5.0.1:
+    resolution:
+      {
+        integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==,
+      }
+    engines: { node: '>=6' }
+    dev: true
+
+  /events/3.3.0:
+    resolution:
+      {
+        integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==,
+      }
+    engines: { node: '>=0.8.x' }
+    dev: true
+
   /execa/4.1.0:
     resolution:
       {
@@ -5920,6 +6566,62 @@ packages:
       jest-util: 28.1.3
     dev: true
 
+  /express-rate-limit/5.5.1:
+    resolution:
+      {
+        integrity: sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg==,
+      }
+    dev: true
+
+  /express/4.18.2:
+    resolution:
+      {
+        integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==,
+      }
+    engines: { node: '>= 0.10.0' }
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.1
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.5.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /extend/3.0.2:
+    resolution:
+      {
+        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+      }
+    dev: true
+
   /external-editor/3.1.0:
     resolution:
       {
@@ -5930,6 +6632,14 @@ packages:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+    dev: true
+
+  /extsprintf/1.3.0:
+    resolution:
+      {
+        integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==,
+      }
+    engines: { '0': node >=0.6.0 }
     dev: true
 
   /fast-deep-equal/3.1.3:
@@ -5977,6 +6687,21 @@ packages:
     resolution:
       {
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
+    dev: true
+
+  /fast-redact/3.1.2:
+    resolution:
+      {
+        integrity: sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==,
+      }
+    engines: { node: '>=6' }
+    dev: true
+
+  /fast-safe-stringify/2.1.1:
+    resolution:
+      {
+        integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
       }
     dev: true
 
@@ -6032,6 +6757,24 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       to-regex-range: 5.0.1
+
+  /finalhandler/1.2.0:
+    resolution:
+      {
+        integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==,
+      }
+    engines: { node: '>= 0.8' }
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /find-node-modules/2.1.3:
     resolution:
@@ -6132,6 +6875,25 @@ packages:
       debug:
         optional: true
 
+  /forever-agent/0.6.1:
+    resolution:
+      {
+        integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==,
+      }
+    dev: true
+
+  /form-data/2.3.3:
+    resolution:
+      {
+        integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==,
+      }
+    engines: { node: '>= 0.12' }
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
+
   /form-data/4.0.0:
     resolution:
       {
@@ -6142,6 +6904,22 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  /forwarded/0.2.0:
+    resolution:
+      {
+        integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
+  /fresh/0.5.2:
+    resolution:
+      {
+        integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
 
   /fs-constants/1.0.0:
     resolution:
@@ -6235,6 +7013,17 @@ packages:
       }
     dev: true
 
+  /get-intrinsic/1.2.0:
+    resolution:
+      {
+        integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==,
+      }
+    dependencies:
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.3
+    dev: true
+
   /get-package-type/0.1.0:
     resolution:
       {
@@ -6280,6 +7069,15 @@ packages:
       {
         integrity: sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==,
       }
+    dev: true
+
+  /getpass/0.1.7:
+    resolution:
+      {
+        integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==,
+      }
+    dependencies:
+      assert-plus: 1.0.0
     dev: true
 
   /git-raw-commits/2.0.11:
@@ -6346,6 +7144,19 @@ packages:
     engines: { node: '>=10.13.0' }
     dependencies:
       is-glob: 4.0.3
+    dev: true
+
+  /glob/6.0.4:
+    resolution:
+      {
+        integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==,
+      }
+    dependencies:
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
     dev: true
 
   /glob/7.1.4:
@@ -6464,6 +7275,26 @@ packages:
       uglify-js: 3.17.4
     dev: true
 
+  /har-schema/2.0.0:
+    resolution:
+      {
+        integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==,
+      }
+    engines: { node: '>=4' }
+    dev: true
+
+  /har-validator/5.1.5:
+    resolution:
+      {
+        integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==,
+      }
+    engines: { node: '>=6' }
+    deprecated: this library is no longer supported
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
+    dev: true
+
   /hard-rejection/2.1.0:
     resolution:
       {
@@ -6492,6 +7323,14 @@ packages:
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
       }
     engines: { node: '>=8' }
+
+  /has-symbols/1.0.3:
+    resolution:
+      {
+        integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==,
+      }
+    engines: { node: '>= 0.4' }
+    dev: true
 
   /has/1.0.3:
     resolution:
@@ -6546,6 +7385,34 @@ packages:
       }
     dev: true
 
+  /http-errors/1.8.1:
+    resolution:
+      {
+        integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==,
+      }
+    engines: { node: '>= 0.6' }
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 1.5.0
+      toidentifier: 1.0.1
+    dev: true
+
+  /http-errors/2.0.0:
+    resolution:
+      {
+        integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==,
+      }
+    engines: { node: '>= 0.8' }
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+    dev: true
+
   /http-proxy-agent/5.0.0:
     resolution:
       {
@@ -6558,6 +7425,25 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /http-signature/1.2.0:
+    resolution:
+      {
+        integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==,
+      }
+    engines: { node: '>=0.8', npm: '>=1.3.7' }
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.17.0
+    dev: true
+
+  /http-status-codes/2.2.0:
+    resolution:
+      {
+        integrity: sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==,
+      }
     dev: true
 
   /https-proxy-agent/5.0.1:
@@ -6779,6 +7665,14 @@ packages:
     engines: { node: '>=8' }
     dev: true
 
+  /ipaddr.js/1.9.1:
+    resolution:
+      {
+        integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==,
+      }
+    engines: { node: '>= 0.10' }
+    dev: true
+
   /is-arrayish/0.2.1:
     resolution:
       {
@@ -6879,6 +7773,13 @@ packages:
       }
     dev: true
 
+  /is-promise/2.2.2:
+    resolution:
+      {
+        integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==,
+      }
+    dev: true
+
   /is-stream/2.0.1:
     resolution:
       {
@@ -6895,6 +7796,13 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       text-extensions: 1.9.0
+    dev: true
+
+  /is-typedarray/1.0.0:
+    resolution:
+      {
+        integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==,
+      }
     dev: true
 
   /is-unicode-supported/0.1.0:
@@ -6959,6 +7867,13 @@ packages:
     resolution:
       {
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
+    dev: true
+
+  /isstream/0.1.2:
+    resolution:
+      {
+        integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==,
       }
     dev: true
 
@@ -7693,6 +8608,13 @@ packages:
     dependencies:
       argparse: 2.0.1
 
+  /jsbn/0.1.1:
+    resolution:
+      {
+        integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==,
+      }
+    dev: true
+
   /jsdom/19.0.0:
     resolution:
       {
@@ -7792,6 +8714,13 @@ packages:
       }
     dev: true
 
+  /json-schema/0.4.0:
+    resolution:
+      {
+        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
+      }
+    dev: true
+
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution:
       {
@@ -7860,6 +8789,63 @@ packages:
     engines: { '0': node >= 0.2.0 }
     dev: true
 
+  /jsonwebtoken/9.0.0:
+    resolution:
+      {
+        integrity: sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==,
+      }
+    engines: { node: '>=12', npm: '>=6' }
+    dependencies:
+      jws: 3.2.2
+      lodash: 4.17.21
+      ms: 2.1.2
+      semver: 7.3.8
+    dev: true
+
+  /jsprim/1.4.2:
+    resolution:
+      {
+        integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==,
+      }
+    engines: { node: '>=0.6.0' }
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+    dev: true
+
+  /jwa/1.4.1:
+    resolution:
+      {
+        integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==,
+      }
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+    dev: true
+
+  /jws/3.2.2:
+    resolution:
+      {
+        integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==,
+      }
+    dependencies:
+      jwa: 1.4.1
+      safe-buffer: 5.2.1
+    dev: true
+
+  /keygrip/1.1.0:
+    resolution:
+      {
+        integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==,
+      }
+    engines: { node: '>= 0.6' }
+    dependencies:
+      tsscmp: 1.0.6
+    dev: true
+
   /kill-port/2.0.1:
     resolution:
       {
@@ -7883,6 +8869,14 @@ packages:
     resolution:
       {
         integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+      }
+    engines: { node: '>=6' }
+    dev: true
+
+  /kleur/4.1.5:
+    resolution:
+      {
+        integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==,
       }
     engines: { node: '>=6' }
     dev: true
@@ -7980,6 +8974,22 @@ packages:
     engines: { node: '>=10' }
     dependencies:
       p-locate: 5.0.0
+    dev: true
+
+  /lockfile/1.0.4:
+    resolution:
+      {
+        integrity: sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==,
+      }
+    dependencies:
+      signal-exit: 3.0.7
+    dev: true
+
+  /lodash-es/4.17.21:
+    resolution:
+      {
+        integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==,
+      }
     dev: true
 
   /lodash.camelcase/4.3.0:
@@ -8114,6 +9124,20 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /lowdb/1.0.0:
+    resolution:
+      {
+        integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==,
+      }
+    engines: { node: '>=4' }
+    dependencies:
+      graceful-fs: 4.2.10
+      is-promise: 2.2.2
+      lodash: 4.17.21
+      pify: 3.0.0
+      steno: 0.4.4
+    dev: true
+
   /lru-cache/5.1.1:
     resolution:
       {
@@ -8130,6 +9154,30 @@ packages:
     engines: { node: '>=10' }
     dependencies:
       yallist: 4.0.0
+
+  /lru-cache/7.14.1:
+    resolution:
+      {
+        integrity: sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==,
+      }
+    engines: { node: '>=12' }
+    dev: true
+
+  /lunr-mutable-indexes/2.3.2:
+    resolution:
+      {
+        integrity: sha512-Han6cdWAPPFM7C2AigS2Ofl3XjAT0yVMrUixodJEpyg71zCtZ2yzXc3s+suc/OaNt4ca6WJBEzVnEIjxCTwFMw==,
+      }
+    dependencies:
+      lunr: 2.3.9
+    dev: true
+
+  /lunr/2.3.9:
+    resolution:
+      {
+        integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==,
+      }
+    dev: true
 
   /make-dir/3.1.0:
     resolution:
@@ -8173,6 +9221,14 @@ packages:
     engines: { node: '>=8' }
     dev: true
 
+  /media-typer/0.3.0:
+    resolution:
+      {
+        integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
   /meow/8.1.2:
     resolution:
       {
@@ -8191,6 +9247,13 @@ packages:
       trim-newlines: 3.0.1
       type-fest: 0.18.1
       yargs-parser: 20.2.9
+    dev: true
+
+  /merge-descriptors/1.0.1:
+    resolution:
+      {
+        integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==,
+      }
     dev: true
 
   /merge-stream/2.0.0:
@@ -8213,6 +9276,14 @@ packages:
         integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
       }
     engines: { node: '>= 8' }
+
+  /methods/1.1.2:
+    resolution:
+      {
+        integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
 
   /micromatch/4.0.5:
     resolution:
@@ -8239,6 +9310,33 @@ packages:
     engines: { node: '>= 0.6' }
     dependencies:
       mime-db: 1.52.0
+
+  /mime/1.6.0:
+    resolution:
+      {
+        integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==,
+      }
+    engines: { node: '>=4' }
+    hasBin: true
+    dev: true
+
+  /mime/2.6.0:
+    resolution:
+      {
+        integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==,
+      }
+    engines: { node: '>=4.0.0' }
+    hasBin: true
+    dev: true
+
+  /mime/3.0.0:
+    resolution:
+      {
+        integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==,
+      }
+    engines: { node: '>=10.0.0' }
+    hasBin: true
+    dev: true
 
   /mimic-fn/2.1.0:
     resolution:
@@ -8305,6 +9403,25 @@ packages:
         integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==,
       }
 
+  /mkdirp/0.5.6:
+    resolution:
+      {
+        integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==,
+      }
+    hasBin: true
+    dependencies:
+      minimist: 1.2.7
+    dev: true
+
+  /mkdirp/1.0.4:
+    resolution:
+      {
+        integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==,
+      }
+    engines: { node: '>=10' }
+    hasBin: true
+    dev: true
+
   /modify-values/1.0.1:
     resolution:
       {
@@ -8321,11 +9438,25 @@ packages:
     engines: { node: '>=4' }
     dev: true
 
+  /ms/2.0.0:
+    resolution:
+      {
+        integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==,
+      }
+    dev: true
+
   /ms/2.1.2:
     resolution:
       {
         integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==,
       }
+
+  /ms/2.1.3:
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+    dev: true
 
   /multimatch/4.0.0:
     resolution:
@@ -8345,6 +9476,25 @@ packages:
     resolution:
       {
         integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==,
+      }
+    dev: true
+
+  /mv/2.1.1:
+    resolution:
+      {
+        integrity: sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==,
+      }
+    engines: { node: '>=0.8.0' }
+    dependencies:
+      mkdirp: 0.5.6
+      ncp: 2.0.0
+      rimraf: 2.4.5
+    dev: true
+
+  /nanoclone/0.2.1:
+    resolution:
+      {
+        integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==,
       }
     dev: true
 
@@ -8371,6 +9521,22 @@ packages:
       }
     dev: true
 
+  /ncp/2.0.0:
+    resolution:
+      {
+        integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==,
+      }
+    hasBin: true
+    dev: true
+
+  /negotiator/0.6.3:
+    resolution:
+      {
+        integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
   /neo-async/2.6.2:
     resolution:
       {
@@ -8378,19 +9544,20 @@ packages:
       }
     dev: true
 
-  /ngx-deploy-npm/4.3.11_nx@15.6.1+typescript@4.8.4:
+  /ngx-deploy-npm/5.2.0_ewjtrlfj6y4uoq4loh4g4t525u:
     resolution:
       {
-        integrity: sha512-2fvT7+u9iIdzlgkM3iMiQeQyl275RYG7REj7pW/Whve5reoKfkvQn3MLfxAYg/86QZrahHYR4TOhlKr/ccy/VQ==,
+        integrity: sha512-+lsBNlDQ6Lr0fBN2eV+kbiExnPJwmuTK0cz1HBzvi+13DWu/AgAwy5o7bA+IkZL5pS6f4alJpjqY+TDMfGpubw==,
       }
     engines: { node: '>=14.0.0' }
     peerDependencies:
-      nx: 15.6.2
+      '@nrwl/devkit': ^14.0.0 || ^15.0.0
+      '@nrwl/workspace': ^14.0.0 || ^15.0.0
+      nx: ^14.0.0 || ^15.0.0
     dependencies:
-      '@nrwl/devkit': 15.6.2_nx@15.6.1+typescript@4.8.4
+      '@nrwl/devkit': 15.6.1_nx@15.6.1+typescript@4.8.4
+      '@nrwl/workspace': 15.6.1_5yonbsjlpewldw7hu6fyirxww4
       nx: 15.6.1_lwc5ciab46qbgcufzept4zyhgi
-    transitivePeerDependencies:
-      - typescript
     dev: true
 
   /node-addon-api/3.2.1:
@@ -8592,6 +9759,53 @@ packages:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - debug
+
+  /oauth-sign/0.9.0:
+    resolution:
+      {
+        integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==,
+      }
+    dev: true
+
+  /object-assign/4.1.1:
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: '>=0.10.0' }
+    dev: true
+
+  /object-inspect/1.12.3:
+    resolution:
+      {
+        integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==,
+      }
+    dev: true
+
+  /on-exit-leak-free/0.2.0:
+    resolution:
+      {
+        integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==,
+      }
+    dev: true
+
+  /on-finished/2.4.1:
+    resolution:
+      {
+        integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==,
+      }
+    engines: { node: '>= 0.8' }
+    dependencies:
+      ee-first: 1.1.1
+    dev: true
+
+  /on-headers/1.0.2:
+    resolution:
+      {
+        integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
 
   /once/1.4.0:
     resolution:
@@ -8800,6 +10014,14 @@ packages:
       }
     dev: true
 
+  /parseurl/1.3.3:
+    resolution:
+      {
+        integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
   /path-exists/3.0.0:
     resolution:
       {
@@ -8836,6 +10058,13 @@ packages:
         integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
       }
 
+  /path-to-regexp/0.1.7:
+    resolution:
+      {
+        integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==,
+      }
+    dev: true
+
   /path-type/3.0.0:
     resolution:
       {
@@ -8867,6 +10096,13 @@ packages:
       }
     engines: { node: '>=0.10' }
     hasBin: true
+    dev: true
+
+  /performance-now/2.1.0:
+    resolution:
+      {
+        integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==,
+      }
     dev: true
 
   /picocolors/1.0.0:
@@ -8906,6 +10142,53 @@ packages:
     engines: { node: '>=10' }
     dev: true
 
+  /pino-abstract-transport/0.5.0:
+    resolution:
+      {
+        integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==,
+      }
+    dependencies:
+      duplexify: 4.1.2
+      split2: 4.1.0
+    dev: true
+
+  /pino-abstract-transport/1.0.0:
+    resolution:
+      {
+        integrity: sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==,
+      }
+    dependencies:
+      readable-stream: 4.3.0
+      split2: 4.1.0
+    dev: true
+
+  /pino-std-serializers/4.0.0:
+    resolution:
+      {
+        integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==,
+      }
+    dev: true
+
+  /pino/7.11.0:
+    resolution:
+      {
+        integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==,
+      }
+    hasBin: true
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.1.2
+      on-exit-leak-free: 0.2.0
+      pino-abstract-transport: 0.5.0
+      pino-std-serializers: 4.0.0
+      process-warning: 1.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.1.0
+      safe-stable-stringify: 2.4.2
+      sonic-boom: 2.8.0
+      thread-stream: 0.15.2
+    dev: true
+
   /pirates/4.0.5:
     resolution:
       {
@@ -8921,6 +10204,14 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       find-up: 4.1.0
+    dev: true
+
+  /pkginfo/0.4.1:
+    resolution:
+      {
+        integrity: sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==,
+      }
+    engines: { node: '>= 0.4.0' }
     dev: true
 
   /playwright-core/1.30.0:
@@ -9020,6 +10311,21 @@ packages:
       }
     dev: true
 
+  /process-warning/1.0.0:
+    resolution:
+      {
+        integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==,
+      }
+    dev: true
+
+  /process/0.11.10:
+    resolution:
+      {
+        integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==,
+      }
+    engines: { node: '>= 0.6.0' }
+    dev: true
+
   /prompts/2.4.2:
     resolution:
       {
@@ -9029,6 +10335,24 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+    dev: true
+
+  /property-expr/2.0.5:
+    resolution:
+      {
+        integrity: sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==,
+      }
+    dev: true
+
+  /proxy-addr/2.0.7:
+    resolution:
+      {
+        integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
+      }
+    engines: { node: '>= 0.10' }
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
     dev: true
 
   /proxy-from-env/1.1.0:
@@ -9054,6 +10378,13 @@ packages:
       once: 1.4.0
     dev: true
 
+  /punycode/1.4.1:
+    resolution:
+      {
+        integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==,
+      }
+    dev: true
+
   /punycode/2.1.1:
     resolution:
       {
@@ -9070,6 +10401,24 @@ packages:
     engines: { node: '>=0.6.0', teleport: '>=0.2.0' }
     dev: true
 
+  /qs/6.11.0:
+    resolution:
+      {
+        integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==,
+      }
+    engines: { node: '>=0.6' }
+    dependencies:
+      side-channel: 1.0.4
+    dev: true
+
+  /qs/6.5.3:
+    resolution:
+      {
+        integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==,
+      }
+    engines: { node: '>=0.6' }
+    dev: true
+
   /querystringify/2.2.0:
     resolution:
       {
@@ -9083,12 +10432,40 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
+  /quick-format-unescaped/4.0.4:
+    resolution:
+      {
+        integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
+      }
+    dev: true
+
   /quick-lru/4.0.1:
     resolution:
       {
         integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==,
       }
     engines: { node: '>=8' }
+    dev: true
+
+  /range-parser/1.2.1:
+    resolution:
+      {
+        integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
+  /raw-body/2.5.1:
+    resolution:
+      {
+        integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==,
+      }
+    engines: { node: '>= 0.8' }
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
     dev: true
 
   /react-is/17.0.2:
@@ -9179,6 +10556,19 @@ packages:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  /readable-stream/4.3.0:
+    resolution:
+      {
+        integrity: sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+    dev: true
+
   /readdirp/3.6.0:
     resolution:
       {
@@ -9187,6 +10577,14 @@ packages:
     engines: { node: '>=8.10.0' }
     dependencies:
       picomatch: 2.3.1
+
+  /real-require/0.1.0:
+    resolution:
+      {
+        integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==,
+      }
+    engines: { node: '>= 12.13.0' }
+    dev: true
 
   /redent/3.0.0:
     resolution:
@@ -9264,6 +10662,36 @@ packages:
     hasBin: true
     dependencies:
       jsesc: 0.5.0
+
+  /request/2.88.0:
+    resolution:
+      {
+        integrity: sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==,
+      }
+    engines: { node: '>= 4' }
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.12.0
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.3
+      safe-buffer: 5.2.1
+      tough-cookie: 2.4.3
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+    dev: true
 
   /require-directory/2.1.1:
     resolution:
@@ -9376,6 +10804,16 @@ packages:
       }
     engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
 
+  /rimraf/2.4.5:
+    resolution:
+      {
+        integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==,
+      }
+    hasBin: true
+    dependencies:
+      glob: 6.0.4
+    dev: true
+
   /rimraf/3.0.2:
     resolution:
       {
@@ -9443,6 +10881,14 @@ packages:
         integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
       }
 
+  /safe-stable-stringify/2.4.2:
+    resolution:
+      {
+        integrity: sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==,
+      }
+    engines: { node: '>=10' }
+    dev: true
+
   /safer-buffer/2.1.2:
     resolution:
       {
@@ -9507,10 +10953,56 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /send/0.18.0:
+    resolution:
+      {
+        integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==,
+      }
+    engines: { node: '>= 0.8.0' }
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /serve-static/1.15.0:
+    resolution:
+      {
+        integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==,
+      }
+    engines: { node: '>= 0.8.0' }
+    dependencies:
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /set-blocking/2.0.0:
     resolution:
       {
         integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==,
+      }
+    dev: true
+
+  /setprototypeof/1.2.0:
+    resolution:
+      {
+        integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
       }
     dev: true
 
@@ -9539,6 +11031,17 @@ packages:
       }
     dev: true
 
+  /side-channel/1.0.4:
+    resolution:
+      {
+        integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==,
+      }
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
+    dev: true
+
   /signal-exit/3.0.7:
     resolution:
       {
@@ -9558,6 +11061,24 @@ packages:
         integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
       }
     engines: { node: '>=8' }
+    dev: true
+
+  /sonic-boom/2.8.0:
+    resolution:
+      {
+        integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==,
+      }
+    dependencies:
+      atomic-sleep: 1.0.0
+    dev: true
+
+  /sonic-boom/3.2.1:
+    resolution:
+      {
+        integrity: sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==,
+      }
+    dependencies:
+      atomic-sleep: 1.0.0
     dev: true
 
   /source-map-js/1.0.2:
@@ -9663,11 +11184,38 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
+  /split2/4.1.0:
+    resolution:
+      {
+        integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==,
+      }
+    engines: { node: '>= 10.x' }
+    dev: true
+
   /sprintf-js/1.0.3:
     resolution:
       {
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
       }
+
+  /sshpk/1.17.0:
+    resolution:
+      {
+        integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==,
+      }
+    engines: { node: '>=0.10.0' }
+    hasBin: true
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+    dev: true
 
   /stack-utils/2.0.6:
     resolution:
@@ -9677,6 +11225,38 @@ packages:
     engines: { node: '>=10' }
     dependencies:
       escape-string-regexp: 2.0.0
+    dev: true
+
+  /statuses/1.5.0:
+    resolution:
+      {
+        integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==,
+      }
+    engines: { node: '>= 0.6' }
+    dev: true
+
+  /statuses/2.0.1:
+    resolution:
+      {
+        integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
+  /steno/0.4.4:
+    resolution:
+      {
+        integrity: sha512-EEHMVYHNXFHfGtgjNITnka0aHhiAlo93F7z2/Pwd+g0teG9CnM3JIINM7hVVB5/rhw9voufD7Wukwgtw2uqh6w==,
+      }
+    dependencies:
+      graceful-fs: 4.2.10
+    dev: true
+
+  /stream-shift/1.0.1:
+    resolution:
+      {
+        integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==,
+      }
     dev: true
 
   /streamsearch/1.1.0:
@@ -9913,6 +11493,15 @@ packages:
       }
     dev: true
 
+  /thread-stream/0.15.2:
+    resolution:
+      {
+        integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==,
+      }
+    dependencies:
+      real-require: 0.1.0
+    dev: true
+
   /through/2.3.8:
     resolution:
       {
@@ -10002,6 +11591,32 @@ packages:
     engines: { node: '>=8.0' }
     dependencies:
       is-number: 7.0.0
+
+  /toidentifier/1.0.1:
+    resolution:
+      {
+        integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
+      }
+    engines: { node: '>=0.6' }
+    dev: true
+
+  /toposort/2.0.2:
+    resolution:
+      {
+        integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==,
+      }
+    dev: true
+
+  /tough-cookie/2.4.3:
+    resolution:
+      {
+        integrity: sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==,
+      }
+    engines: { node: '>=0.8' }
+    dependencies:
+      psl: 1.9.0
+      punycode: 1.4.1
+    dev: true
 
   /tough-cookie/4.1.2:
     resolution:
@@ -10175,6 +11790,14 @@ packages:
         integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==,
       }
 
+  /tsscmp/1.0.6:
+    resolution:
+      {
+        integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==,
+      }
+    engines: { node: '>=0.6.x' }
+    dev: true
+
   /tsutils/3.21.0_typescript@4.8.4:
     resolution:
       {
@@ -10186,6 +11809,29 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.8.4
+    dev: true
+
+  /tunnel-agent/0.6.0:
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /tweetnacl/0.14.5:
+    resolution:
+      {
+        integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==,
+      }
+    dev: true
+
+  /typanion/3.12.1:
+    resolution:
+      {
+        integrity: sha512-3SJF/czpzqq6G3lprGFLa6ps12yb1uQ1EmitNnep2fDMNh1aO/Zbq9sWY+3lem0zYb2oHJnQWyabTGUZ+L1ScQ==,
+      }
     dev: true
 
   /type-check/0.3.2:
@@ -10254,6 +11900,17 @@ packages:
         integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==,
       }
     engines: { node: '>=8' }
+    dev: true
+
+  /type-is/1.6.18:
+    resolution:
+      {
+        integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==,
+      }
+    engines: { node: '>= 0.6' }
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
     dev: true
 
   /typedarray/0.0.6:
@@ -10338,6 +11995,21 @@ packages:
       }
     engines: { node: '>= 10.0.0' }
 
+  /unix-crypt-td-js/1.1.4:
+    resolution:
+      {
+        integrity: sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==,
+      }
+    dev: true
+
+  /unpipe/1.0.0:
+    resolution:
+      {
+        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
   /update-browserslist-db/1.0.10_browserslist@4.21.4:
     resolution:
       {
@@ -10376,6 +12048,23 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
+  /utils-merge/1.0.1:
+    resolution:
+      {
+        integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==,
+      }
+    engines: { node: '>= 0.4.0' }
+    dev: true
+
+  /uuid/3.4.0:
+    resolution:
+      {
+        integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==,
+      }
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+    dev: true
+
   /v8-compile-cache-lib/3.0.1:
     resolution:
       {
@@ -10409,6 +12098,115 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /validator/13.7.0:
+    resolution:
+      {
+        integrity: sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==,
+      }
+    engines: { node: '>= 0.10' }
+    dev: true
+
+  /vary/1.1.2:
+    resolution:
+      {
+        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+      }
+    engines: { node: '>= 0.8' }
+    dev: true
+
+  /verdaccio-audit/11.0.0-6-next.23:
+    resolution:
+      {
+        integrity: sha512-4TmBfglknSIgLVKUOrhx9ArtI715Ju2SJnyoP0e7DIM1vEdw3Njt1GTG44L47r+n+rB7I6rsrM0/MxKffUmjNQ==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      '@verdaccio/config': 6.0.0-6-next.60
+      '@verdaccio/core': 6.0.0-6-next.60
+      express: 4.18.2
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /verdaccio-htpasswd/10.5.2:
+    resolution:
+      {
+        integrity: sha512-bO5Wm8w07pWswNvwFWjNEoznuUU37CcfblcrU0Ci8c038EgTu2V47uwh4AyZ4PTK6ps9oxHqA7a1b+83sY0OkA==,
+      }
+    engines: { node: '>=8' }
+    dependencies:
+      '@verdaccio/file-locking': 10.3.0
+      apache-md5: 1.1.8
+      bcryptjs: 2.4.3
+      http-errors: 2.0.0
+      unix-crypt-td-js: 1.1.4
+    dev: true
+
+  /verdaccio/5.21.1_typanion@3.12.1:
+    resolution:
+      {
+        integrity: sha512-SbqeKxmcUW1G9AYo8cmAPAlWW6YpNR8Q6LVJrfP+4s9gQ496s8cvhj0yAX8nl1k3+DAEZBuGcrgfAF0kORYXpA==,
+      }
+    engines: { node: '>=12.18' }
+    hasBin: true
+    dependencies:
+      '@verdaccio/config': 6.0.0-6-next.61
+      '@verdaccio/core': 6.0.0-6-next.61
+      '@verdaccio/local-storage': 10.3.1
+      '@verdaccio/logger-7': 6.0.0-6-next.6
+      '@verdaccio/middleware': 6.0.0-6-next.40
+      '@verdaccio/streams': 10.2.0
+      '@verdaccio/tarball': 11.0.0-6-next.30
+      '@verdaccio/ui-theme': 6.0.0-6-next.61
+      '@verdaccio/url': 11.0.0-6-next.27
+      '@verdaccio/utils': 6.0.0-6-next.29
+      JSONStream: 1.3.5
+      async: 3.2.4
+      body-parser: 1.20.1
+      clipanion: 3.2.0-rc.14_typanion@3.12.1
+      compression: 1.7.4
+      cookies: 0.8.0
+      cors: 2.8.5
+      debug: 4.3.4
+      envinfo: 7.8.1
+      express: 4.18.2
+      fast-safe-stringify: 2.1.1
+      handlebars: 4.7.7
+      js-yaml: 4.1.0
+      jsonwebtoken: 9.0.0
+      kleur: 4.1.5
+      lodash: 4.17.21
+      lunr-mutable-indexes: 2.3.2
+      mime: 3.0.0
+      mkdirp: 1.0.4
+      mv: 2.1.1
+      pkginfo: 0.4.1
+      request: 2.88.0
+      semver: 7.3.8
+      validator: 13.7.0
+      verdaccio-audit: 11.0.0-6-next.23
+      verdaccio-htpasswd: 10.5.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - typanion
+    dev: true
+
+  /verror/1.10.0:
+    resolution:
+      {
+        integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==,
+      }
+    engines: { '0': node >=0.6.0 }
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
     dev: true
 
   /vite/4.1.1_@types+node@16.11.7:
@@ -10754,6 +12552,14 @@ packages:
       }
     engines: { node: '>= 6' }
 
+  /yaml/2.2.0:
+    resolution:
+      {
+        integrity: sha512-auf7Gi6QwO7HW//GA9seGvTXVGWl1CM/ADWh1+RxtXr6XOxnT65ovDl9fTi4e0monEyJxCHqDpF6QnFDXmJE4g==,
+      }
+    engines: { node: '>= 14' }
+    dev: true
+
   /yargs-parser/18.1.3:
     resolution:
       {
@@ -10845,4 +12651,20 @@ packages:
         integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
       }
     engines: { node: '>=10' }
+    dev: true
+
+  /yup/0.32.11:
+    resolution:
+      {
+        integrity: sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==,
+      }
+    engines: { node: '>=10' }
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@types/lodash': 4.14.191
+      lodash: 4.17.21
+      lodash-es: 4.17.21
+      nanoclone: 0.2.1
+      property-expr: 2.0.5
+      toposort: 2.0.2
     dev: true

--- a/scripts/local-registry.sh
+++ b/scripts/local-registry.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# source: https://github.com/nrwl/nx/blob/master/scripts/local-registry.sh
+
+COMMAND=$1
+
+if [[ $COMMAND == "enable" ]]; then
+	echo "Setting registry to local registry"
+	echo "To Disable: pnpm run local-registry disable"
+	npm config set registry http://localhost:4873/ --location user
+	yarn config set registry http://localhost:4873/
+fi
+
+if [[ $COMMAND == "disable" ]]; then
+	npm config delete registry --location user
+	yarn config delete registry
+	CURRENT_NPM_REGISTRY=$(npm config get registry --location user)
+	CURRENT_YARN_REGISTRY=$(yarn config get registry)
+
+	echo "Reverting registries"
+	echo "  > NPM:  $CURRENT_NPM_REGISTRY"
+	echo "  > YARN: $CURRENT_YARN_REIGSTRY"
+fi
+
+if [[ $COMMAND == "clear" ]]; then
+	echo "Clearing Local Registry"
+	rm -rf ./tmp/local-registry/storage
+fi
+
+if [[ $COMMAND == "start" ]]; then
+	echo "Starting Local Registry"
+	pwd
+	VERDACCIO_HANDLE_KILL_SIGNALS=true
+	pnpm exec verdaccio --config ./.verdaccio/config.yml
+fi


### PR DESCRIPTION
Right now the description of local publishing is completely irrelevant, it's not possible to run it in the way it is described in our docs. 

Additionally to this working with verdaccio might not be that straightforward, because it is needed to explicitly specify what registry to pull from, how to clean it and so on.

Instead of this it might be better to use the same approach Nx team has in their repository: the bash script that will allow to run few plain commands to start/stop/clean the local registry. 

Publishing process itself is also improved: prior to this PR I have created a pull to ngx-deploy-npm adding the `registry` option. With this in place, starting from `ngx-deploy-npm@5.2.0` it is now possible to publish to another registry using nx target configuration (`nx run qwik-nx:publish:local` in our case)