### PR TITLE
fix(qwik-nx): preset generator should check for the presense of peerDeps

### DIFF
--- a/packages/qwik-nx/src/generators/preset/generator.spec.ts
+++ b/packages/qwik-nx/src/generators/preset/generator.spec.ts
@@ -5,7 +5,17 @@ import generator from './generator';
 import { QwikWorkspacePresetGeneratorSchema } from './schema';
 import { Linter } from '@nrwl/linter';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const devkit = require('@nrwl/devkit');
+const getInstalledNxVersionModule = require('../../utils/get-installed-nx-version');
+
 describe('preset generator', () => {
+  jest.spyOn(devkit, 'ensurePackage').mockReturnValue(Promise.resolve());
+
+  jest
+    .spyOn(getInstalledNxVersionModule, 'getInstalledNxVersion')
+    .mockReturnValue('15.6.0');
+
   let appTree: Tree;
   const options: QwikWorkspacePresetGeneratorSchema = {
     name: 'test',

--- a/packages/qwik-nx/src/generators/preset/generator.ts
+++ b/packages/qwik-nx/src/generators/preset/generator.ts
@@ -1,13 +1,16 @@
-import { Tree } from '@nrwl/devkit';
+import { ensurePackage, Tree } from '@nrwl/devkit';
 import { QwikWorkspacePresetGeneratorSchema } from './schema';
-import applicationGenerator from '../application/generator';
+import { appGenerator } from '../application/generator';
+import { getInstalledNxVersion } from '../../utils/get-installed-nx-version';
 
 export default async function (
   tree: Tree,
   options: QwikWorkspacePresetGeneratorSchema
 ) {
+  await ensurePackage(tree, '@nrwl/vite', getInstalledNxVersion(tree));
+
   options.directory = '';
   options.name = options.qwikAppName ?? options.name;
   options.style = options.qwikAppStyle ?? options.style;
-  return applicationGenerator(tree, options);
+  return appGenerator(tree, options);
 }

--- a/packages/qwik-nx/src/utils/get-installed-nx-version.ts
+++ b/packages/qwik-nx/src/utils/get-installed-nx-version.ts
@@ -1,9 +1,21 @@
 import { readJson, Tree } from '@nrwl/devkit';
+import { PackageJson } from 'nx/src/utils/package-json';
+
+function readNxVersion(packageJson: PackageJson) {
+  return (
+    packageJson?.devDependencies?.['nx'] ??
+    packageJson?.dependencies?.['nx'] ??
+    packageJson?.devDependencies?.['@nrwl/workspace'] ??
+    packageJson?.dependencies?.['@nrwl/workspace']
+  );
+}
 
 export function getInstalledNxVersion(tree: Tree): string {
-  const pkgJson = readJson(tree, 'package.json');
-  if (pkgJson.devDependencies && pkgJson.devDependencies['@nrwl/workspace']) {
-    return pkgJson.devDependencies['@nrwl/workspace'];
+  const pkgJson: PackageJson = readJson(tree, 'package.json');
+  const version = readNxVersion(pkgJson);
+
+  if (version) {
+    return version;
   }
   throw new Error('Could not resolve nx version from the package.json');
 }


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
When repository is created, peer dependencies are not installed by default. Because of this `@nrwl/vite` is not available and an error is thrown. 

Along with this checking for the installed nx version should be improved: it's not enough to check for the presence of `@nrwl/workspace` in devDependencies

closes https://github.com/qwikifiers/qwik-nx/issues/89
# Use cases and why

<!-- Actual / expected behavior if it's a bug -->


# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-nx/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
