### PR TITLE
fix(qwik-nx): migrations.json should not be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
-migrations.json
+./migrations.json
 
 # System Files
 .DS_Store


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
`migrations.json` file was added into `.gitignore`, because of this it wasn't included in the built package
