### PR TITLE
feat(qwik-nx): bump qwik deps and exclude qwik package from peer dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,9 @@ it can be useful to publish to a local registry.
 - Run `npm adduser --registry http://localhost:4873` in Terminal 2 (real credentials are not required, you just need to
   be logged in. You can use test/test/test@test.io.)
 - Run `pnpm run local-registry enable` in Terminal 2
-- Run `pnpm run nx run qwik-nx:publish:local` in Terminal 2. You can set the version you want to publish in the package's package.json file.
+- Run `pnpm exec nx run qwik-nx:publish:local` in Terminal 2. You can set the version you want to publish in the package's package.json file.
 
-If you have problems publishing, make sure you use Node 18 and NPM 8. Alternatively to running the project's "publish" target you can build and publish manually by running `pnpm run nx build:qwik-nx && cd dist/projects/qwik-nx && npm publish --registry=http://localhost:4873`
+If you have problems publishing, make sure you use Node 18 and NPM 8. Alternatively to running the project's "publish" target you can build and publish manually by running `pnpm exec nx build:qwik-nx && cd dist/projects/qwik-nx && npm publish --registry=http://localhost:4873`
 
 **NOTE:** After you finish with local testing don't forget to stop the local registry (e.g. closing the Terminal 1) and disabling the local registry using `pnpm run local-registry disable`. Keeping local registry enabled will change your lock file resolutions to `localhost:4873` on the next `pnpm install`. You can also run `pnpm run local-registry clear` to clean all packages in that local registry.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ nx generate qwik-nx:route
 nx generate qwik-nx:setup-tailwind
 ```
 
+## Migrations
+
+This plugin supports Nx migrations and provides necessary version and code updates for Qwik. So instead of bumping plugin version manually in package.json it's recommended to run `nx migrate qwik-nx` command, that includes bumping the version of the qwik-nx plugin, related dependencies and running code migrations.
+
 ## qwik-nx & Nx Compatibility Chart
 
 | qwik-nx version     | Nx version |

--- a/e2e/qwik-nx-e2e/tests/chore.spec.ts
+++ b/e2e/qwik-nx-e2e/tests/chore.spec.ts
@@ -28,11 +28,6 @@ describe('appGenerator e2e', () => {
       expect(packageJson.dependencies).toBeUndefined();
       expect(packageJson.peerDependencies).toEqual({
         '@nrwl/vite': '^15.8.0',
-        '@builder.io/qwik': '^0.17.0',
-        '@playwright/test': '^1.30.0',
-        undici: '^5.18.0',
-        vite: '^4.0.0',
-        vitest: '^0.25.0',
         tslib: '^2.3.0',
       });
     }, 200000);

--- a/packages/qwik-nx/migrations.json
+++ b/packages/qwik-nx/migrations.json
@@ -66,6 +66,17 @@
           "version": "^3.20.6"
         }
       }
+    },
+    "0.13.2": {
+      "version": "0.13.2",
+      "packages": {
+        "@builder.io/qwik": {
+          "version": "~0.21.0"
+        },
+        "eslint-plugin-qwik": {
+          "version": "~0.21.0"
+        }
+      }
     }
   }
 }

--- a/packages/qwik-nx/package.json
+++ b/packages/qwik-nx/package.json
@@ -22,12 +22,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@nrwl/vite": "^15.8.0",
-    "@builder.io/qwik": "^0.17.0",
-    "vite": "^4.0.0",
-    "vitest": "^0.25.0",
-    "@playwright/test": "^1.30.0",
-    "undici": "^5.18.0"
+    "@nrwl/vite": "^15.8.0"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.ts
+++ b/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.ts
@@ -1,9 +1,14 @@
-import { type QwikVitePlugin } from '@builder.io/qwik/optimizer';
 import { type Plugin } from 'vite';
 import { join } from 'path';
 import { readWorkspaceConfig } from 'nx/src/project-graph/file-utils';
 import { ProjectConfiguration, workspaceRoot } from '@nrwl/devkit';
 import { readFileSync } from 'fs';
+
+interface QwikVitePluginStub {
+  api: {
+    getOptions: () => { vendorRoots: string[] };
+  };
+}
 
 export interface ProjectFilter {
   name?: string[] | RegExp;
@@ -35,7 +40,7 @@ export function qwikNxVite(options?: QwikNxVitePluginOptions): Plugin {
     async configResolved(config) {
       const qwikPlugin = config.plugins.find(
         (p) => p.name === 'vite-plugin-qwik'
-      ) as QwikVitePlugin;
+      ) as QwikVitePluginStub;
       if (!qwikPlugin) {
         throw new Error('Missing vite-plugin-qwik');
       }

--- a/packages/qwik-nx/src/utils/versions.ts
+++ b/packages/qwik-nx/src/utils/versions.ts
@@ -1,7 +1,7 @@
 // qwik packages
-export const qwikVersion = '~0.20.0';
+export const qwikVersion = '~0.21.0';
 export const qwikCityVersion = '~0.5.0';
-export const qwikEslintPluginVersion = '~0.20.0';
+export const qwikEslintPluginVersion = '~0.21.0';
 
 // css preprocessors
 export const sassVersion = '~1.56.1';


### PR DESCRIPTION
- bumping qwik dependencies to version 0.21, which addresses critical vulnerability
- removed unnecessary peer dependencies 