### PR TITLE
fix(qwik-nx): add missing @nrwl/* packages to qwik-nx to ensure they resolve correctly

### DIFF
--- a/e2e/qwik-nx-e2e/tests/chore.spec.ts
+++ b/e2e/qwik-nx-e2e/tests/chore.spec.ts
@@ -27,6 +27,9 @@ describe('appGenerator e2e', () => {
 
       expect(packageJson.dependencies).toBeUndefined();
       expect(packageJson.peerDependencies).toEqual({
+        '@nrwl/devkit': '^15.8.0',
+        '@nrwl/js': '^15.8.0',
+        '@nrwl/linter': '^15.8.0',
         '@nrwl/vite': '^15.8.0',
         tslib: '^2.3.0',
       });

--- a/packages/qwik-nx/package.json
+++ b/packages/qwik-nx/package.json
@@ -22,6 +22,9 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
+    "@nrwl/devkit": "^15.8.0",
+    "@nrwl/js": "^15.8.0",
+    "@nrwl/linter": "^15.8.0",
     "@nrwl/vite": "^15.8.0"
   },
   "nx-migrations": {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

When generating apps with `qwik-nx:app` there is an error due to missing `@nrwl/linter` dependency. It was pulled in previously because of this dependency chain: `qwik-nx -> @nrwl/vite -> @nrwl/js -> @nrwl/linter`. In Nx 15.9.0, we removed the `@nrwl/js -> @nrwl/devkit` dependency so the latter package is no longer installed.

Adding these missing packages removes the reliance on them being hoisted by a package manager.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. `create-nx-workspace --preset=qwik-nx`
- 2. `nx g qwik-nx:app`

# Screenshots/Demo
<img width="1254" alt="Screenshot 2023-03-31 at 8 42 37 AM" src="https://user-images.githubusercontent.com/53559/229123015-f518e46e-f822-4e5c-b76e-d7fbd5414480.png">



# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-nx/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality