### PR TITLE
feat(qwik-nx): qwikNxVite plugin to include only project's dependencies  by default

### DIFF
--- a/packages/qwik-nx/src/plugins/index.ts
+++ b/packages/qwik-nx/src/plugins/index.ts
@@ -1,1 +1,5 @@
 export * from './qwik-nx-vite.plugin';
+export type {
+  ProjectFilter,
+  QwikNxVitePluginOptions,
+} from './models/qwik-nx-vite';

--- a/packages/qwik-nx/src/plugins/models/qwik-nx-vite.ts
+++ b/packages/qwik-nx/src/plugins/models/qwik-nx-vite.ts
@@ -1,0 +1,37 @@
+import { ProjectConfiguration } from '@nrwl/devkit';
+
+export interface ProjectFilter {
+  name?: string[] | RegExp;
+  path?: RegExp;
+  tags?: string[];
+  customFilter?: (project: ProjectConfiguration) => boolean;
+}
+
+export interface QwikNxVitePluginOptions {
+  /**
+   * Name of the project, with which plugin is used. By default it will be resolved using the path of the `rootDir` from the Vite environment.
+   */
+  currentProjectName?: string;
+  /**
+   * Projects to be included as vendor roots for Qwik to be able to run optimizer over them.
+   * If not specified, will include all projects that are recognized as dependencies of the given `currentProjectName`.
+   */
+  includeProjects?: ProjectFilter;
+  /**
+   *  Projects to be excluded from the list of resolved vendor roots.
+   */
+  excludeProjects?: ProjectFilter;
+  debug?: boolean;
+}
+
+export interface QwikVitePluginStub {
+  api: {
+    getOptions: () => QwikVitePluginOptionsStub;
+  };
+}
+
+export interface QwikVitePluginOptionsStub {
+  vendorRoots: string[];
+  rootDir: string;
+  debug: boolean;
+}

--- a/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.spec.ts
+++ b/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.spec.ts
@@ -1,11 +1,14 @@
 import { workspaceRoot } from '@nrwl/devkit';
 import { join } from 'path';
-import { qwikNxVite, QwikNxVitePluginOptions } from './qwik-nx-vite.plugin';
+import { qwikNxVite } from './qwik-nx-vite.plugin';
+import { QwikNxVitePluginOptions } from './models/qwik-nx-vite';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fileUtils = require('nx/src/project-graph/file-utils');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const getProjectDependenciesModule = require('./utils/get-project-dependencies');
 
 const workspaceConfig1 = {
   projects: {
@@ -86,6 +89,11 @@ describe('qwik-nx-vite plugin', () => {
     .spyOn(fileUtils, 'readWorkspaceConfig')
     .mockReturnValue(workspaceConfig1);
   jest.spyOn(fs, 'readFileSync').mockReturnValue(tsConfigString1);
+  jest
+    .spyOn(getProjectDependenciesModule, 'getProjectDependencies')
+    .mockReturnValue(
+      Promise.resolve(new Set(Object.keys(workspaceConfig1.projects)))
+    );
 
   /**
    * @param options options for the qwikNxVite plugin
@@ -132,7 +140,7 @@ describe('qwik-nx-vite plugin', () => {
     ]);
   });
 
-  describe('Should not include current porject as a vendor root for itself', () => {
+  describe('Should not include current project as a vendor root for itself', () => {
     it('with project name specified', async () => {
       const paths = await getDecoratedPaths({
         currentProjectName: 'tmp-test-lib-a',

--- a/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.spec.ts
+++ b/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.spec.ts
@@ -10,89 +10,93 @@ const fs = require('fs');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const getProjectDependenciesModule = require('./utils/get-project-dependencies');
 
-const workspaceConfig1 = {
-  projects: {
-    'tmp-test-app-a': {
-      root: 'apps/test-app-a',
-      name: 'tmp-test-app-a',
-      projectType: 'application',
-      sourceRoot: 'apps/test-app-a/src',
-      prefix: 'tmp',
-      tags: ['tag1', 'tag2'],
+function getWorkspaceConfig() {
+  return {
+    projects: {
+      'tmp-test-app-a': {
+        root: 'apps/test-app-a',
+        name: 'tmp-test-app-a',
+        projectType: 'application',
+        sourceRoot: 'apps/test-app-a/src',
+        prefix: 'tmp',
+        tags: ['tag1', 'tag2'],
+      },
+      'tmp-test-lib-a': {
+        root: 'libs/test-lib-a',
+        name: 'tmp-test-lib-a',
+        projectType: 'library',
+        sourceRoot: 'libs/test-lib-a/src',
+        prefix: 'tmp',
+        tags: ['tag2'],
+      },
+      'tmp-test-lib-b': {
+        root: 'libs/test-lib-b',
+        name: 'tmp-test-lib-b',
+        projectType: 'library',
+        sourceRoot: 'libs/test-lib-b/src',
+        prefix: 'tmp',
+        tags: ['tag2', 'tag3'],
+      },
+      'tmp-test-lib-c-nested-1': {
+        root: 'libs/test-lib-c/nested',
+        name: 'tmp-test-lib-c-nested-1',
+        projectType: 'library',
+        sourceRoot: 'libs/test-lib-c/nested-1/src',
+        prefix: 'tmp',
+        tags: ['tag4'],
+      },
+      'tmp-test-lib-c-nested-2': {
+        root: 'libs/test-lib-c/nested',
+        name: 'tmp-test-lib-c-nested-2',
+        projectType: 'library',
+        sourceRoot: 'libs/test-lib-c/nested-2/src',
+        prefix: 'tmp',
+        tags: ['tag1', 'tag2', 'tag3'],
+      },
+      'tmp-other-test-lib-a': {
+        root: 'libs/other/test-lib-a',
+        name: 'tmp-other-test-lib-a',
+        projectType: 'library',
+        sourceRoot: 'libs/other/test-lib-a/src',
+        prefix: 'tmp',
+        tags: [],
+      },
+      // it will be excluded because it is not set in our mock tsconfig.json
+      'tmp-always-excluded': {
+        root: 'libs/always/excluded',
+        name: 'tmp-always-excluded',
+        projectType: 'library',
+        sourceRoot: 'libs/always/excluded/src',
+        prefix: 'tmp',
+        tags: [],
+      },
     },
-    'tmp-test-lib-a': {
-      root: 'libs/test-lib-a',
-      name: 'tmp-test-lib-a',
-      projectType: 'library',
-      sourceRoot: 'libs/test-lib-a/src',
-      prefix: 'tmp',
-      tags: ['tag2'],
-    },
-    'tmp-test-lib-b': {
-      root: 'libs/test-lib-b',
-      name: 'tmp-test-lib-b',
-      projectType: 'library',
-      sourceRoot: 'libs/test-lib-b/src',
-      prefix: 'tmp',
-      tags: ['tag2', 'tag3'],
-    },
-    'tmp-test-lib-c-nested-1': {
-      root: 'libs/test-lib-c/nested',
-      name: 'tmp-test-lib-c-nested-1',
-      projectType: 'library',
-      sourceRoot: 'libs/test-lib-c/nested-1/src',
-      prefix: 'tmp',
-      tags: ['tag4'],
-    },
-    'tmp-test-lib-c-nested-2': {
-      root: 'libs/test-lib-c/nested',
-      name: 'tmp-test-lib-c-nested-2',
-      projectType: 'library',
-      sourceRoot: 'libs/test-lib-c/nested-2/src',
-      prefix: 'tmp',
-      tags: ['tag1', 'tag2', 'tag3'],
-    },
-    'tmp-other-test-lib-a': {
-      root: 'libs/other/test-lib-a',
-      name: 'tmp-other-test-lib-a',
-      projectType: 'library',
-      sourceRoot: 'libs/other/test-lib-a/src',
-      prefix: 'tmp',
-      tags: [],
-    },
-    // it will be excluded because it is not set in our mock tsconfig.json
-    'tmp-always-excluded': {
-      root: 'libs/always/excluded',
-      name: 'tmp-always-excluded',
-      projectType: 'library',
-      sourceRoot: 'libs/always/excluded/src',
-      prefix: 'tmp',
-      tags: [],
-    },
-  },
-};
+  };
+}
 
-const tsConfigString1 = JSON.stringify({
-  compilerOptions: {
-    paths: {
-      '@tmp/test-lib-a': 'libs/test-lib-a/src/index.ts',
-      '@tmp/test-lib-b': 'libs/test-lib-b/src/index.ts',
-      '@tmp/test-lib-c/nested-1': 'libs/test-lib-c/nested-1/src/index.ts',
-      '@tmp/test-lib-c/nested-2': 'libs/test-lib-c/nested-2/src/index.ts',
-      '@tmp/other/test-lib-a/nested-2': 'libs/other/test-lib-a/src/index.ts',
+function getTsConfigString() {
+  return JSON.stringify({
+    compilerOptions: {
+      paths: {
+        '@tmp/test-lib-a': 'libs/test-lib-a/src/index.ts',
+        '@tmp/test-lib-b': 'libs/test-lib-b/src/index.ts',
+        '@tmp/test-lib-c/nested-1': 'libs/test-lib-c/nested-1/src/index.ts',
+        '@tmp/test-lib-c/nested-2': 'libs/test-lib-c/nested-2/src/index.ts',
+        '@tmp/other/test-lib-a/nested-2': 'libs/other/test-lib-a/src/index.ts',
+      },
     },
-  },
-});
+  });
+}
 
 describe('qwik-nx-vite plugin', () => {
   jest
     .spyOn(fileUtils, 'readWorkspaceConfig')
-    .mockReturnValue(workspaceConfig1);
-  jest.spyOn(fs, 'readFileSync').mockReturnValue(tsConfigString1);
+    .mockReturnValue(getWorkspaceConfig());
+  jest.spyOn(fs, 'readFileSync').mockReturnValue(getTsConfigString());
   jest
     .spyOn(getProjectDependenciesModule, 'getProjectDependencies')
     .mockReturnValue(
-      Promise.resolve(new Set(Object.keys(workspaceConfig1.projects)))
+      Promise.resolve(new Set(Object.keys(getWorkspaceConfig().projects)))
     );
 
   /**

--- a/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.ts
+++ b/packages/qwik-nx/src/plugins/qwik-nx-vite.plugin.ts
@@ -1,52 +1,19 @@
 import { type Plugin } from 'vite';
-import { join, relative } from 'path';
-import { readWorkspaceConfig } from 'nx/src/project-graph/file-utils';
 import {
-  createProjectRootMappingsFromProjectConfigurations,
-  findProjectForPath,
-} from 'nx/src/project-graph/utils/find-project-for-path';
-import {
-  ProjectConfiguration,
-  ProjectsConfigurations,
-  workspaceRoot,
-  normalizePath,
-} from '@nrwl/devkit';
-import { readFileSync } from 'fs';
-
-interface QwikVitePluginStub {
-  api: {
-    getOptions: () => QwikVitePluginOptionsStub;
-  };
-}
-
-interface QwikVitePluginOptionsStub {
-  vendorRoots: string[];
-  rootDir: string;
-  debug: boolean;
-}
-
-export interface ProjectFilter {
-  name?: string[] | RegExp;
-  path?: RegExp;
-  tags?: string[];
-  customFilter?: (project: ProjectConfiguration) => boolean;
-}
-
-export interface QwikNxVitePluginOptions {
-  currentProjectName?: string;
-  includeProjects?: ProjectFilter;
-  excludeProjects?: ProjectFilter;
-  debug?: boolean;
-}
+  QwikNxVitePluginOptions,
+  QwikVitePluginStub,
+} from './models/qwik-nx-vite';
+import { getVendorRoots } from './utils/get-vendor-roots';
 
 /**
  * `qwikNxVite` plugin serves as an integration step between Qwik and Nx.
  * At this point its main purpose is to provide Nx libraries as vendor roots for the Qwik.
  * This is required in order for the optimizer to be able to work with entities imported from those libs.
  *
- * By default `qwikNxVite` plugin will provide Qwik with paths of all Nx projects, that are specified in the tsconfig.base.json.
- * However, this behavior might not be always suitable, especially in cases when you have code that you don't want the optimizer to go through.
- * It is possible to specifically exclude or include certain projects using plugin options.
+ * If `options.includeProjects` is not provided, `qwikNxVite` plugin will provide Qwik with paths of Nx projects,
+ * that are recognized as dependencies of the current one and are specified in the tsconfig.base.json.
+ * this behavior is customizable: you can exclude additional projects by providing `options.excludeProjects`
+ * or completely control what's included by using `options.includeProjects`
  */
 export function qwikNxVite(options?: QwikNxVitePluginOptions): Plugin {
   const vitePlugin: Plugin = {
@@ -63,182 +30,11 @@ export function qwikNxVite(options?: QwikNxVitePluginOptions): Plugin {
 
       const pluginOptions = qwikPlugin.api.getOptions();
 
-      const vendorRoots = getVendorRoots(options, pluginOptions);
+      const vendorRoots = await getVendorRoots(options, pluginOptions);
 
       pluginOptions.vendorRoots.push(...vendorRoots);
     },
   };
 
   return vitePlugin;
-}
-
-function getCurrentProjectName(
-  projectsConfigurations: ProjectsConfigurations,
-  projectRootDir: string
-): string {
-  const projectRootMappings =
-    createProjectRootMappingsFromProjectConfigurations(
-      projectsConfigurations.projects
-    );
-  const relativeDirname = relative(workspaceRoot, projectRootDir);
-  const normalizedRelativeDirname = normalizePath(relativeDirname);
-  const currentProjectName = findProjectForPath(
-    normalizedRelativeDirname,
-    projectRootMappings
-  );
-
-  if (!currentProjectName) {
-    throw new Error(
-      `Could not resolve the project name for path "${projectRootDir}"`
-    );
-  }
-  return currentProjectName;
-}
-
-/** Retrieves vendor roots and applies necessary filtering */
-function getVendorRoots(
-  options: QwikNxVitePluginOptions | undefined,
-  qwikOptions: QwikVitePluginOptionsStub
-): string[] {
-  const log = (...str: unknown[]) => {
-    (options?.debug || qwikOptions.debug) &&
-      console.debug(`[QWIK-NX-VITE PLUGIN:]`, ...str);
-  };
-
-  const workspaceConfig = readWorkspaceConfig({ format: 'nx' });
-
-  const baseTsConfig = JSON.parse(
-    readFileSync(join(workspaceRoot, 'tsconfig.base.json')).toString()
-  );
-  const decoratedPaths = Object.values<string[]>(
-    baseTsConfig.compilerOptions.paths
-  ).flat();
-
-  let projects = Object.values(workspaceConfig.projects);
-
-  if (
-    options?.currentProjectName &&
-    !workspaceConfig.projects[options.currentProjectName]
-  ) {
-    throw new Error(
-      `Could not find project with name "${options.currentProjectName}"`
-    );
-  }
-
-  const currentProjectName =
-    options?.currentProjectName ??
-    getCurrentProjectName(workspaceConfig, qwikOptions.rootDir);
-
-  projects = projects.filter((p) => p.name !== currentProjectName);
-
-  projects.forEach((p) => (p.sourceRoot ??= p.root));
-
-  projects = filterProjects(projects, options?.excludeProjects, true);
-  projects = filterProjects(projects, options?.includeProjects, false);
-
-  if (options?.debug) {
-    log(
-      'Projects after applying include\\exclude filters:',
-      projects.map((p) => p.name)
-    );
-  }
-
-  projects = projects.filter((p) =>
-    decoratedPaths.some((path) => path.startsWith(p.sourceRoot!))
-  );
-
-  if (options?.debug) {
-    log(
-      'Projects after excluding those not in tsconfig.base.json:',
-      projects.map((p) => p.name)
-    );
-  }
-
-  return projects.map((p) => p.sourceRoot).map((p) => join(workspaceRoot, p!));
-}
-
-function filterProjects(
-  projects: ProjectConfiguration[],
-  filterConfig: ProjectFilter | undefined,
-  exclusive: boolean
-): ProjectConfiguration[] {
-  if (filterConfig?.name) {
-    projects = filterProjectsByName(projects, filterConfig.name, exclusive);
-  }
-  if (filterConfig?.path) {
-    projects = filterProjectsByPath(projects, filterConfig.path, exclusive);
-  }
-  if (filterConfig?.tags?.length) {
-    projects = filterProjectsByTags(projects, filterConfig.tags, exclusive);
-  }
-  if (typeof filterConfig?.customFilter === 'function') {
-    projects = projects.filter((p) => {
-      const matches = filterConfig.customFilter!(p);
-      return exclusive ? !matches : matches;
-    });
-  }
-  return projects;
-}
-
-function filterProjectsByName(
-  projects: ProjectConfiguration[],
-  options: string[] | RegExp,
-  exclusive: boolean
-): ProjectConfiguration[] {
-  if (Array.isArray(options)) {
-    const optionsSet = new Set(options);
-    return projects.filter((p) => {
-      const matches = optionsSet.has(p.name!);
-      return exclusive ? !matches : matches;
-    });
-  } else if (options instanceof RegExp) {
-    return filterByRegex(projects, options, exclusive, (p) => p.name!);
-  }
-  return projects;
-}
-
-function filterProjectsByPath(
-  projects: ProjectConfiguration[],
-  options: RegExp,
-  exclusive: boolean
-): ProjectConfiguration[] {
-  if (options instanceof RegExp) {
-    return filterByRegex(projects, options, exclusive, (p) => p.sourceRoot!);
-  }
-  return projects;
-}
-
-function filterByRegex(
-  projects: ProjectConfiguration[],
-  options: RegExp,
-  exclusive: boolean,
-  valueGetter: (p: ProjectConfiguration) => string
-): ProjectConfiguration[] {
-  if (options instanceof RegExp) {
-    if (options.global) {
-      console.log(`"global" flag has been removed from the RegExp ${options}`);
-      options = new RegExp(options.source, options.flags.replace('g', ''));
-    }
-    return projects.filter((p) => {
-      const matches = (options as RegExp).test(valueGetter(p));
-      return exclusive ? !matches : matches;
-    });
-  }
-  return projects;
-}
-
-function filterProjectsByTags(
-  projects: ProjectConfiguration[],
-  tags: string[],
-  exclusive: boolean
-): ProjectConfiguration[] {
-  if (exclusive) {
-    return projects.filter((p) => {
-      return tags.every((t) => !p.tags?.includes(t));
-    });
-  } else {
-    return projects.filter((p) => {
-      return tags.every((t) => p.tags?.includes(t));
-    });
-  }
 }

--- a/packages/qwik-nx/src/plugins/utils/current-project-name.ts
+++ b/packages/qwik-nx/src/plugins/utils/current-project-name.ts
@@ -1,0 +1,33 @@
+import {
+  ProjectsConfigurations,
+  normalizePath,
+  workspaceRoot,
+} from '@nrwl/devkit';
+import {
+  createProjectRootMappingsFromProjectConfigurations,
+  findProjectForPath,
+} from 'nx/src/project-graph/utils/find-project-for-path';
+import { relative } from 'path';
+
+export function getCurrentProjectName(
+  projectsConfigurations: ProjectsConfigurations,
+  projectRootDir: string
+): string {
+  const projectRootMappings =
+    createProjectRootMappingsFromProjectConfigurations(
+      projectsConfigurations.projects
+    );
+  const relativeDirname = relative(workspaceRoot, projectRootDir);
+  const normalizedRelativeDirname = normalizePath(relativeDirname);
+  const currentProjectName = findProjectForPath(
+    normalizedRelativeDirname,
+    projectRootMappings
+  );
+
+  if (!currentProjectName) {
+    throw new Error(
+      `Could not resolve the project name for path "${projectRootDir}"`
+    );
+  }
+  return currentProjectName;
+}

--- a/packages/qwik-nx/src/plugins/utils/filter-projects.ts
+++ b/packages/qwik-nx/src/plugins/utils/filter-projects.ts
@@ -1,0 +1,88 @@
+import { ProjectConfiguration } from '@nrwl/devkit';
+import { ProjectFilter } from '../models/qwik-nx-vite';
+
+export function filterProjects(
+  projects: ProjectConfiguration[],
+  filterConfig: ProjectFilter | undefined,
+  exclusive: boolean
+): ProjectConfiguration[] {
+  if (filterConfig?.name) {
+    projects = filterProjectsByName(projects, filterConfig.name, exclusive);
+  }
+  if (filterConfig?.path) {
+    projects = filterProjectsByPath(projects, filterConfig.path, exclusive);
+  }
+  if (filterConfig?.tags?.length) {
+    projects = filterProjectsByTags(projects, filterConfig.tags, exclusive);
+  }
+  if (typeof filterConfig?.customFilter === 'function') {
+    projects = projects.filter((p) => {
+      const matches = filterConfig.customFilter!(p);
+      return exclusive ? !matches : matches;
+    });
+  }
+  return projects;
+}
+
+function filterProjectsByName(
+  projects: ProjectConfiguration[],
+  options: string[] | RegExp,
+  exclusive: boolean
+): ProjectConfiguration[] {
+  if (Array.isArray(options)) {
+    const optionsSet = new Set(options);
+    return projects.filter((p) => {
+      const matches = optionsSet.has(p.name!);
+      return exclusive ? !matches : matches;
+    });
+  } else if (options instanceof RegExp) {
+    return filterByRegex(projects, options, exclusive, (p) => p.name!);
+  }
+  return projects;
+}
+
+function filterProjectsByPath(
+  projects: ProjectConfiguration[],
+  options: RegExp,
+  exclusive: boolean
+): ProjectConfiguration[] {
+  if (options instanceof RegExp) {
+    return filterByRegex(projects, options, exclusive, (p) => p.sourceRoot!);
+  }
+  return projects;
+}
+
+function filterByRegex(
+  projects: ProjectConfiguration[],
+  options: RegExp,
+  exclusive: boolean,
+  valueGetter: (p: ProjectConfiguration) => string
+): ProjectConfiguration[] {
+  if (options instanceof RegExp) {
+    if (options.global) {
+      console.log(`"global" flag has been removed from the RegExp ${options}`);
+      options = new RegExp(options.source, options.flags.replace('g', ''));
+    }
+    return projects.filter((p) => {
+      const matches = (options as RegExp).test(valueGetter(p));
+      return exclusive ? !matches : matches;
+    });
+  }
+  return projects;
+}
+
+function filterProjectsByTags(
+  projects: ProjectConfiguration[],
+  tags: string[],
+  exclusive: boolean
+): ProjectConfiguration[] {
+  if (exclusive) {
+    return projects.filter((p) => {
+      return tags.every((t) => !p.tags?.includes(t));
+    });
+  } else {
+    return projects.filter((p) => {
+      return tags.every((t) => p.tags?.includes(t));
+    });
+  }
+}

--- a/packages/qwik-nx/src/plugins/utils/get-project-dependencies.ts
+++ b/packages/qwik-nx/src/plugins/utils/get-project-dependencies.ts
@@ -1,0 +1,28 @@
+import { ProjectGraph, createProjectGraphAsync } from '@nrwl/devkit';
+import { pruneExternalNodes } from 'nx/src/project-graph/operators';
+
+/** Retrieves all projects given `currentProjectName` depends on */
+export async function getProjectDependencies(
+  currentProjectName: string
+): Promise<ReadonlySet<string>> {
+  const graph = pruneExternalNodes(
+    await createProjectGraphAsync({ exitOnError: true })
+  );
+  return traverseGraph(graph, currentProjectName);
+}
+
+function traverseGraph(
+  graph: ProjectGraph,
+  root: string,
+  visited = new Set<string>()
+) {
+  if (visited.has(root)) return visited;
+
+  visited.add(root);
+  const nodes = graph.dependencies[root].map((d) => d.target);
+
+  for (const node of nodes) {
+    traverseGraph(graph, node, visited);
+  }
+  return visited;
+}

--- a/packages/qwik-nx/src/plugins/utils/get-vendor-roots.ts
+++ b/packages/qwik-nx/src/plugins/utils/get-vendor-roots.ts
@@ -1,0 +1,85 @@
+import { readWorkspaceConfig } from 'nx/src/project-graph/file-utils';
+import {
+  QwikNxVitePluginOptions,
+  QwikVitePluginOptionsStub,
+} from '../models/qwik-nx-vite';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { workspaceRoot } from '@nrwl/devkit';
+import { getCurrentProjectName } from './current-project-name';
+import { filterProjects } from './filter-projects';
+import { getProjectDependencies } from './get-project-dependencies';
+
+/** Retrieves vendor roots and applies necessary filtering */
+export async function getVendorRoots(
+  options: QwikNxVitePluginOptions | undefined,
+  qwikOptions: QwikVitePluginOptionsStub
+): Promise<string[]> {
+  const log = (...str: unknown[]) => {
+    (options?.debug || qwikOptions.debug) &&
+      console.debug(`[QWIK-NX-VITE PLUGIN:]`, ...str);
+  };
+
+  const workspaceConfig = readWorkspaceConfig({ format: 'nx' });
+
+  const baseTsConfig = JSON.parse(
+    readFileSync(join(workspaceRoot, 'tsconfig.base.json')).toString()
+  );
+  const decoratedPaths = Object.values<string[]>(
+    baseTsConfig.compilerOptions.paths
+  ).flat();
+
+  let projects = Object.values(workspaceConfig.projects);
+
+  if (
+    options?.currentProjectName &&
+    !workspaceConfig.projects[options.currentProjectName]
+  ) {
+    throw new Error(
+      `Could not find project with name "${options.currentProjectName}"`
+    );
+  }
+
+  const currentProjectName =
+    options?.currentProjectName ??
+    getCurrentProjectName(workspaceConfig, qwikOptions.rootDir);
+
+  projects = projects.filter((p) => p.name !== currentProjectName);
+
+  if (!options?.includeProjects) {
+    // by default including only project dependencies
+    const dependencies = await getProjectDependencies(currentProjectName);
+    projects = projects.filter((p) => dependencies.has(p.name!));
+    if (options?.debug) {
+      log(
+        `Dependencies for "${currentProjectName}":`,
+        projects.map((p) => p.name)
+      );
+    }
+  }
+
+  projects.forEach((p) => (p.sourceRoot ??= p.root));
+
+  projects = filterProjects(projects, options?.excludeProjects, true);
+  projects = filterProjects(projects, options?.includeProjects, false);
+
+  if (options?.debug) {
+    log(
+      'Projects after applying include\\exclude filters:',
+      projects.map((p) => p.name)
+    );
+  }
+
+  projects = projects.filter((p) =>
+    decoratedPaths.some((path) => path.startsWith(p.sourceRoot!))
+  );
+
+  if (options?.debug) {
+    log(
+      'Projects after excluding those not in tsconfig.base.json:',
+      projects.map((p) => p.name)
+    );
+  }
+
+  return projects.map((p) => p.sourceRoot).map((p) => join(workspaceRoot, p!));
+}


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
Right now by default qwikNxVite plugin will include all projects from the workspace as vendorRoots. 

This PR changes the default behavior to only include those projects that are recognized by Nx as dependencies of the particular app. In other words, it works like a reversed nx `affected`



