### PR TITLE
feat(qwik-nx): move peer dependencies to dependencies

### DIFF
--- a/e2e/qwik-nx-e2e/tests/chore.spec.ts
+++ b/e2e/qwik-nx-e2e/tests/chore.spec.ts
@@ -28,14 +28,15 @@ describe('appGenerator e2e', () => {
       async () => {
         const packageJson = readJson('node_modules/qwik-nx/package.json');
 
-      expect(packageJson.dependencies).toBeUndefined();
-      expect(packageJson.peerDependencies).toEqual({
-        '@nrwl/devkit': '^15.8.0',
-        '@nrwl/js': '^15.8.0',
-        '@nrwl/linter': '^15.8.0',
-        '@nrwl/vite': '^15.8.0',
-        tslib: '^2.3.0',
-      });
-    }, DEFAULT_E2E_TIMEOUT);
+        expect(packageJson.peerDependencies).toBeUndefined();
+        expect(packageJson.dependencies).toEqual({
+          '@nrwl/devkit': '^15.8.0',
+          '@nrwl/js': '^15.8.0',
+          '@nrwl/linter': '^15.8.0',
+          '@nrwl/vite': '^15.8.0',
+        });
+      },
+      DEFAULT_E2E_TIMEOUT
+    );
   });
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "nx build",
     "commit": "git-cz",
     "format:fix": "pretty-quick --staged",
-    "local-registry": "./scripts/local-registry.sh",
+    "local-registry": "sh ./scripts/local-registry.sh",
     "prepare": "husky install",
     "start": "nx serve",
     "test": "nx test"

--- a/packages/qwik-nx/package.json
+++ b/packages/qwik-nx/package.json
@@ -21,12 +21,11 @@
   },
   "generators": "./generators.json",
   "executors": "./executors.json",
-  "peerDependencies": {
+  "dependencies": {
     "@nrwl/devkit": "^15.8.0",
     "@nrwl/js": "^15.8.0",
     "@nrwl/linter": "^15.8.0",
-    "@nrwl/vite": "^15.8.0",
-    "tslib": "^2.3.0"
+    "@nrwl/vite": "^15.8.0"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/packages/qwik-nx/project.json
+++ b/packages/qwik-nx/project.json
@@ -10,6 +10,7 @@
       "options": {
         "outputPath": "dist/packages/qwik-nx",
         "main": "packages/qwik-nx/src/index.ts",
+        "updateBuildableProjectDepsInPackageJson": false,
         "tsConfig": "packages/qwik-nx/tsconfig.lib.json",
         "assets": [
           "README.md",

--- a/packages/qwik-nx/src/generators/preset/generator.spec.ts
+++ b/packages/qwik-nx/src/generators/preset/generator.spec.ts
@@ -5,14 +5,7 @@ import generator from './generator';
 import { QwikWorkspacePresetGeneratorSchema } from './schema';
 import { Linter } from '@nrwl/linter';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const getInstalledNxVersionModule = require('../../utils/get-installed-nx-version');
-
 describe('preset generator', () => {
-  jest
-    .spyOn(getInstalledNxVersionModule, 'ensurePeerDependenciesInstalled')
-    .mockImplementation();
-
   let appTree: Tree;
   const options: QwikWorkspacePresetGeneratorSchema = {
     name: 'test',

--- a/packages/qwik-nx/src/generators/preset/generator.ts
+++ b/packages/qwik-nx/src/generators/preset/generator.ts
@@ -1,13 +1,10 @@
 import { Tree } from '@nrwl/devkit';
 import { QwikWorkspacePresetGeneratorSchema } from './schema';
-import { ensurePeerDependenciesInstalled } from '../../utils/get-installed-nx-version';
 
 export default async function (
   tree: Tree,
   options: QwikWorkspacePresetGeneratorSchema
 ) {
-  ensurePeerDependenciesInstalled(tree);
-
   options.directory = '';
   options.name = options.qwikAppName ?? options.name;
   options.style = options.qwikAppStyle ?? options.style;

--- a/packages/qwik-nx/src/utils/get-installed-nx-version.ts
+++ b/packages/qwik-nx/src/utils/get-installed-nx-version.ts
@@ -1,4 +1,4 @@
-import { ensurePackage, readJson, Tree } from '@nrwl/devkit';
+import { readJson, Tree } from '@nrwl/devkit';
 import { PackageJson } from 'nx/src/utils/package-json';
 
 function readNxVersion(packageJson: PackageJson) {
@@ -18,21 +18,4 @@ export function getInstalledNxVersion(tree: Tree): string {
     return version;
   }
   throw new Error('Could not resolve nx version from the package.json');
-}
-
-export function ensurePeerDependenciesInstalled(tree: Tree): void {
-  const packageJsonPath = `node_modules/qwik-nx/package.json`;
-  const pkgJson: PackageJson = readJson(tree, packageJsonPath);
-
-  const nxVersion = getInstalledNxVersion(tree);
-
-  for (const [dependency, version] of Object.entries(
-    pkgJson.peerDependencies!
-  )) {
-    if (dependency.startsWith('@nrwl/')) {
-      ensurePackage(dependency, nxVersion);
-    } else {
-      ensurePackage(dependency, version);
-    }
-  }
 }


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
`@nrwl/*` packages that are specified as peer dependencies of `qwik-nx` package are crucial to execute any of the package's generators, thus it makes much more sense to keep them as `dependencies` instead. By adding `updateBuildableProjectDepsInPackageJson` property to project's build target it is possible to make nx executor to not override versions (as it was before). 
