### PR TITLE
fix(qwik-nx): get canonical url from the right path

### DIFF
--- a/packages/qwik-nx/src/generators/application/files/src/components/router-head/router-head.tsx__template__
+++ b/packages/qwik-nx/src/generators/application/files/src/components/router-head/router-head.tsx__template__
@@ -6,13 +6,13 @@ import { useDocumentHead, useLocation } from '@builder.io/qwik-city';
  */
 export const RouterHead = component$(() => {
   const head = useDocumentHead();
-  const loc = useLocation();
+  const { url } = useLocation();
 
   return (
     <>
       <title>{head.title}</title>
 
-      <link rel="canonical" href={loc.href} />
+      <link rel="canonical" href={url.href} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

`useLocation()` returns us a `RouteLocation` instance. So we should get the href from `loc.url.href`.

```ts
export declare interface RouteLocation {
    readonly params: Readonly<Record<string, string>>;
    readonly url: URL;
    readonly isNavigating: boolean;
}
```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Generate qwik application by running `nx generate qwik-nx:application`
- 2. Another use case

# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-nx/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
