### PR TITLE
fix(qwik-nx): drop deprecated `readWorkspaceConfig` in favor of `readCachedProjectGraph`

### DIFF
--- a/packages/qwik-nx/src/plugins/utils/current-project-name.ts
+++ b/packages/qwik-nx/src/plugins/utils/current-project-name.ts
@@ -1,22 +1,15 @@
+import { ProjectGraph, normalizePath, workspaceRoot } from '@nx/devkit';
 import {
-  ProjectsConfigurations,
-  normalizePath,
-  workspaceRoot,
-} from '@nx/devkit';
-import {
-  createProjectRootMappingsFromProjectConfigurations,
+  createProjectRootMappings,
   findProjectForPath,
 } from 'nx/src/project-graph/utils/find-project-for-path';
 import { relative } from 'path';
 
 export function getCurrentProjectName(
-  projectsConfigurations: ProjectsConfigurations,
+  projectGraph: ProjectGraph,
   projectRootDir: string
 ): string {
-  const projectRootMappings =
-    createProjectRootMappingsFromProjectConfigurations(
-      projectsConfigurations.projects
-    );
+  const projectRootMappings = createProjectRootMappings(projectGraph.nodes);
   const relativeDirname = relative(workspaceRoot, projectRootDir);
   const normalizedRelativeDirname = normalizePath(relativeDirname);
   const currentProjectName = findProjectForPath(


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

In our CI, we face a sporadic timeout issue when running a test target that involves `qwikNxVite`. This change fixes the problem by using the right way to get the project graph and project configs, dropping the deprecated `readWorkspaceConfig` API in favor of the devkit.

Note that [Nx 21 removed the function](https://github.com/nrwl/nx/commit/840aef802f9bfd73828434d69d786ceae812b50e#diff-e3dbf0bc765b8ab61c9b38cca6f1f106839b76adba63590f2dc00ac339fdd5e5L192), so it's a needed refactoring anyway.

# Use cases and why

No sporadic timeout issue when running a test target including  `qwikNxVite`.

# Screenshots/Demo



# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-nx/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
