### PR TITLE
fix(qwik-nx): add default reporter for vitest config

### DIFF
--- a/packages/qwik-nx/src/generators/application/files/vite.config.ts__template__
+++ b/packages/qwik-nx/src/generators/application/files/vite.config.ts__template__
@@ -7,7 +7,7 @@ export default defineConfig({
   cacheDir: '<%= offsetFromRoot %>node_modules/.vite/<%= projectRoot %>',
   root: '<%= projectRoot %>',
   plugins: [
-    qwikCity(), 
+    qwikCity(),
     qwikVite({
 			client: {
 				outDir: '<%= offsetFromRoot %>dist/<%= projectRoot %>/client',
@@ -36,7 +36,8 @@ export default defineConfig({
       dir: '<%= offsetFromRoot %>node_modules/.vitest',
     },
     environment: 'node',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default']
   }
   <% } %>
 });

--- a/packages/qwik-nx/src/generators/host/__snapshots__/generator.spec.ts.snap
+++ b/packages/qwik-nx/src/generators/host/__snapshots__/generator.spec.ts.snap
@@ -352,6 +352,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "
@@ -851,6 +852,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "
@@ -1015,6 +1017,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "

--- a/packages/qwik-nx/src/generators/integrations/react-in-app/__snapshots__/generator.spec.ts.snap
+++ b/packages/qwik-nx/src/generators/integrations/react-in-app/__snapshots__/generator.spec.ts.snap
@@ -41,6 +41,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "
@@ -236,6 +237,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "

--- a/packages/qwik-nx/src/generators/integrations/react-library/__snapshots__/generator.spec.ts.snap
+++ b/packages/qwik-nx/src/generators/integrations/react-library/__snapshots__/generator.spec.ts.snap
@@ -108,6 +108,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
     coverage: {
       reportsDirectory: '../../coverage/libs/mylib',
     },
@@ -247,6 +248,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
     coverage: {
       reportsDirectory: '../../coverage/libs/mylib',
     },
@@ -381,6 +383,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "
@@ -427,6 +430,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "

--- a/packages/qwik-nx/src/generators/library/__snapshots__/generator.spec.ts.snap
+++ b/packages/qwik-nx/src/generators/library/__snapshots__/generator.spec.ts.snap
@@ -148,6 +148,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
     coverage: {
       reportsDirectory: '../../coverage/libs/mylib',
     },
@@ -402,6 +403,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
     coverage: {
       reportsDirectory: '../../coverage/libs/mylib',
     },

--- a/packages/qwik-nx/src/generators/library/files/vite.config.ts.template
+++ b/packages/qwik-nx/src/generators/library/files/vite.config.ts.template
@@ -8,7 +8,7 @@ import { join } from 'path';
 export default defineConfig({
   cacheDir: '<%= offsetFromRoot %>node_modules/.vite/<%= projectRoot %>',
   plugins: [
-    qwikVite(), 
+    qwikVite(),
     tsconfigPaths({ root: '<%= offsetFromRoot %>' }),
     <% if(buildable) { %>  dts({
       tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
@@ -42,6 +42,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
     coverage: {
       reportsDirectory: '<%= offsetFromRoot %>coverage/<%= projectRoot %>'
     }

--- a/packages/qwik-nx/src/generators/remote/__snapshots__/generator.spec.ts.snap
+++ b/packages/qwik-nx/src/generators/remote/__snapshots__/generator.spec.ts.snap
@@ -196,6 +196,7 @@ export default defineConfig({
     },
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
   },
 });
 "


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

When generating anything, the vitest config doesn't come with the default reporter, so you don't get any output for successful/failed tests at all. 

Closes: https://github.com/qwikifiers/qwik-nx/issues/253

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Running tests should provide an output for what succeeded/failed

# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-nx/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
